### PR TITLE
Simplify test jobs using `matrix`

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,45 +31,19 @@ blocks:
         - name: codecov-workos-ruby
       jobs:
         - name: Ruby 1.9.3
+          matrix:
+            - env_var: RUBY_VERSION
+              values:
+                - 1.9.3-p551
+                - 2.0.0-p648
+                - 2.3.4
+                - 2.5.7
+                - 2.6.5
+                - 2.7.3
+                - 3.0.2
           commands:
             - checkout
-            - sem-version ruby 1.9.3-p551
-            - bundle install
-            - bundle exec rspec
-        - name: Ruby 2.0.0
-          commands:
-            - checkout
-            - sem-version ruby 2.0.0-p648
-            - bundle install
-            - bundle exec rspec
-        - name: Ruby 2.3.4
-          commands:
-            - checkout
-            - sem-version ruby 2.3.4
-            - bundle install
-            - bundle exec rspec
-        - name: Ruby 2.5.7
-          commands:
-            - checkout
-            - sem-version ruby 2.5.7
-            - bundle install
-            - bundle exec rspec
-        - name: Ruby 2.6.5
-          commands:
-            - checkout
-            - sem-version ruby 2.6.5
-            - bundle install
-            - bundle exec rspec
-        - name: Ruby 2.7.3
-          commands:
-            - checkout
-            - sem-version ruby 2.7.3
-            - bundle install
-            - bundle exec rspec
-        - name: Ruby 3.0.2
-          commands:
-            - checkout
-            - sem-version ruby 3.0.2
+            - sem-version ruby $RUBY_VERSION
             - bundle install
             - bundle exec rspec
 promotions:


### PR DESCRIPTION
Simplifies our Semaphore jobs that test backwards compatibility by using the [`matrix` option](https://docs.semaphoreci.com/essentials/build-matrix/) under `jobs`.