### PR TITLE
uninitialized constant

### DIFF
--- a/lib/workos/types/passwordless_session_struct.rb
+++ b/lib/workos/types/passwordless_session_struct.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # typed: strict
 
+require 'date'
+
 module WorkOS
   module Types
     # This PasswordlessSessionStruct acts as a typed interface


### PR DESCRIPTION
was putzing around with workos in IRB and it exploded due to `Date` being uninitialized...seems like we're missing a require somewhere?  sinatra pulls this in, and many other gems, so this issue does not always present.  repro steps below


```ruby
irb

> require 'workos'
true
> WorkOS::Types::PasswordlessSessionStruct
Traceback (most recent call last):
        ... 10 levels...
         5: from /Users/daniel.pepper/code/workos/sdk-ruby/lib/workos/types.rb:14:in `<module:Types>'
         4: from /Users/daniel.pepper/code/workos/sdk-ruby/lib/workos/types.rb:14:in `require_relative'
         3: from /Users/daniel.pepper/code/workos/sdk-ruby/lib/workos/types/passwordless_session_struct.rb:6:in `<top (required)>'
         2: from /Users/daniel.pepper/code/workos/sdk-ruby/lib/workos/types/passwordless_session_struct.rb:7:in `<module:WorkOS>'
         1: from /Users/daniel.pepper/code/workos/sdk-ruby/lib/workos/types/passwordless_session_struct.rb:10:in `<module:Types>'
/Users/daniel.pepper/code/workos/sdk-ruby/lib/workos/types/passwordless_session_struct.rb:13:in `<class:PasswordlessSessionStruct>': uninitialized constant WorkOS::Types::PasswordlessSessionStruct::Date (NameError)
```

after
```ruby
> require 'workos'
true
> WorkOS::Types::PasswordlessSessionStruct
WorkOS::Types::PasswordlessSessionStruct < T::Struct
```