### PR TITLE
Create 2.2.1 version of the workos gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (2.2.0)
+    workos (2.2.1)
       sorbet-runtime (~> 0.5)
 
 GEM
@@ -60,7 +60,7 @@ GEM
     simplecov_json_formatter (0.1.2)
     sorbet (0.5.6388)
       sorbet-static (= 0.5.6388)
-    sorbet-runtime (0.5.9300)
+    sorbet-runtime (0.5.9944)
     sorbet-static (0.5.6388-universal-darwin-14)
     sorbet-static (0.5.6388-universal-darwin-15)
     sorbet-static (0.5.6388-universal-darwin-16)

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end


### PR DESCRIPTION
Includes fixes from #148 and #152 to address the issue brought up in https://github.com/workos/workos-ruby/issues/147 (and a couple of other PR's that have come in since we'd released 2.2.0)