### PR TITLE
Require expires_at to not be null for authentication challenge

### DIFF
--- a/lib/workos/challenge.rb
+++ b/lib/workos/challenge.rb
@@ -16,7 +16,7 @@ module WorkOS
       raw = parse_json(json)
       @id = T.let(raw.id, String)
       @object = T.let(raw.object, String)
-      @expires_at = raw.expires_at
+      @expires_at = T.let(raw.expires_at, String)
       @code = raw.code
       @authentication_factor_id = T.let(raw.authentication_factor_id, String)
       @created_at = T.let(raw.created_at, String)

--- a/lib/workos/types/challenge_struct.rb
+++ b/lib/workos/types/challenge_struct.rb
@@ -8,7 +8,7 @@ module WorkOS
     class ChallengeStruct < T::Struct
       const :id, String
       const :object, String
-      const :expires_at, T.nilable(String)
+      const :expires_at, String
       const :code, T.nilable(String)
       const :authentication_factor_id, String
       const :created_at, String

--- a/spec/support/fixtures/vcr_cassettes/mfa/challenge_factor_totp_valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/mfa/challenge_factor_totp_valid.yml
@@ -76,7 +76,7 @@ http_interactions:
       - h3=":443"; ma=86400, h3-29=":443"; ma=86400
     body:
       encoding: UTF-8
-      string: '{"object":"authentication_challenge","id":"auth_challenge_01FZ4W3X566NPKJRNB85KHF74F","created_at":"2022-03-27T05:03:25.859Z","updated_at":"2022-03-27T05:03:25.859Z","authentication_factor_id":"auth_factor_01FZ4TS0MWPZR7GATS7KCXANQZ"}'
+      string: '{"object":"authentication_challenge","id":"auth_challenge_01FZ4W3X566NPKJRNB85KHF74F","created_at":"2022-03-27T05:03:25.859Z","updated_at":"2022-03-27T05:03:25.859Z","expires_at":"2022-03-27T05:13:26.204Z","authentication_factor_id":"auth_factor_01FZ4TS0MWPZR7GATS7KCXANQZ"}'
     http_version:
   recorded_at: Sun, 27 Mar 2022 05:03:25 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
Require `expires_at` to no be null for authentication challenge in MFA API