### PR TITLE
v2.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (2.2.1)
+    workos (2.3.0)
       sorbet-runtime (~> 0.5)
 
 GEM
@@ -60,7 +60,7 @@ GEM
     simplecov_json_formatter (0.1.2)
     sorbet (0.5.6388)
       sorbet-static (= 0.5.6388)
-    sorbet-runtime (0.5.9944)
+    sorbet-runtime (0.5.10090)
     sorbet-static (0.5.6388-universal-darwin-14)
     sorbet-static (0.5.6388-universal-darwin-15)
     sorbet-static (0.5.6388-universal-darwin-16)

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '2.2.1'
+  VERSION = '2.3.0'
 end


### PR DESCRIPTION
- Remove `environment_id` fields: https://github.com/workos/workos-ruby/pull/155
- Add `order` pagination parameter: https://github.com/workos/workos-ruby/pull/156/files
- Add `idp_id`, `directory_id`, `created_at`, `updated_at`, and `raw_attributes` to directory group: https://github.com/workos/workos-ruby/pull/157
- Require `expires_at` to not be nullable for authentication challenge: https://github.com/workos/workos-ruby/pull/158
- Add `primary_email` method for Directory User API: https://github.com/workos/workos-ruby/pull/161