### PR TITLE
Make the `Webooks.verify_header` method public

### DIFF
--- a/lib/workos/webhooks.rb
+++ b/lib/workos/webhooks.rb
@@ -55,8 +55,6 @@ module WorkOS
         WorkOS::Webhook.new(payload)
       end
 
-      private
-
       sig do
         params(
           payload: String,
@@ -104,6 +102,8 @@ module WorkOS
         true
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+      private
 
       sig do
         params(


### PR DESCRIPTION
This allows people to semantically verify the body without also parsing the JSON data. This is great for quickly verifying the data in the web process and then stashing it to be parsed and processed in a background process.