### PR TITLE
Only set write_timeout if Ruby version is greater or equal to 2.6.0

### DIFF
--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -13,7 +13,7 @@ module WorkOS
         http_client.use_ssl = true
         http_client.open_timeout = WorkOS.config.timeout
         http_client.read_timeout = WorkOS.config.timeout
-        http_client.write_timeout = WorkOS.config.timeout
+        http_client.write_timeout = WorkOS.config.timeout if RUBY_VERSION >= '2.6.0'
       end
     end
 

--- a/spec/support/shared_examples/client_spec.rb
+++ b/spec/support/shared_examples/client_spec.rb
@@ -13,4 +13,18 @@ RSpec.shared_examples 'client' do
   it 'returns new instance' do
     expect(described_class.client.object_id).to_not eq described_class.client.object_id
   end
+
+  if RUBY_VERSION >= '2.6.0'
+    it 'sets the timeouts, including the write timeout' do
+      expect(described_class.client.open_timeout).to_not be_nil
+      expect(described_class.client.read_timeout).to_not be_nil
+      expect(described_class.client.write_timeout).to_not be_nil
+    end
+  else
+    it 'sets the open and read timeouts, but not the write timeout' do
+      expect(described_class.client.open_timeout).to_not be_nil
+      expect(described_class.client.read_timeout).to_not be_nil
+      expect(described_class.client.write_timeout).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
`write_timeout` is only supported for Ruby version 2.6.0+ so we should check that before setting in order to make the gem backwards compatible for older Ruby versions.