### PR TITLE
Add AuditLogs module

### DIFF
--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -39,6 +39,7 @@ module WorkOS
   autoload :Types, 'workos/types'
   autoload :Client, 'workos/client'
   autoload :Configuration, 'workos/configuration'
+  autoload :AuditLogExport, 'workos/audit_log_export'
   autoload :AuditLogs, 'workos/audit_logs'
   autoload :AuditTrail, 'workos/audit_trail'
   autoload :Connection, 'workos/connection'

--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -39,6 +39,7 @@ module WorkOS
   autoload :Types, 'workos/types'
   autoload :Client, 'workos/client'
   autoload :Configuration, 'workos/configuration'
+  autoload :AuditLogs, 'workos/audit_logs'
   autoload :AuditTrail, 'workos/audit_trail'
   autoload :Connection, 'workos/connection'
   autoload :DirectorySync, 'workos/directory_sync'

--- a/lib/workos/audit_log_export.rb
+++ b/lib/workos/audit_log_export.rb
@@ -2,6 +2,7 @@
 # typed: true
 
 module WorkOS
+  # The AuditLogExport class represents the WorkOS entity created when exporting Audit Log Events.
   class AuditLogExport
     include HashProvider
     extend T::Sig

--- a/lib/workos/audit_log_export.rb
+++ b/lib/workos/audit_log_export.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+# typed: true
+
+module WorkOS
+  class AuditLogExport
+    include HashProvider
+    extend T::Sig
+
+    attr_accessor :object, :id, :state, :url, :created_at, :updated_at
+
+    sig { params(json: String).void }
+    def initialize(json)
+      raw = parse_json(json)
+
+      @object = T.let(raw.object, String)
+      @id = T.let(raw.id, String)
+      @state = T.let(raw.state, String)
+      @url = raw.url
+      @created_at = T.let(raw.created_at, String)
+      @updated_at = T.let(raw.updated_at, String)
+    end
+
+    def to_json(*)
+      {
+        object: object,
+        id: id,
+        state: state,
+        url: url,
+        created_at: created_at,
+        updated_at: updated_at,
+      }
+    end
+
+    private
+
+    sig do
+      params(
+        json_string: String,
+      ).returns(WorkOS::Types::AuditLogExportStruct)
+    end
+    def parse_json(json_string)
+      hash = JSON.parse(json_string, symbolize_names: true)
+
+      WorkOS::Types::AuditLogExportStruct.new(
+        object: hash[:object],
+        id: hash[:id],
+        state: hash[:state],
+        url: hash[:url],
+        created_at: hash[:created_at],
+        updated_at: hash[:updated_at],
+      )
+    end
+  end
+end

--- a/lib/workos/audit_logs.rb
+++ b/lib/workos/audit_logs.rb
@@ -24,7 +24,7 @@ module WorkOS
           organization: String,
           event: Hash,
           idempotency_key: T.nilable(String),
-        ).returns(::T.untyped)
+        ).void
       end
       def create_event(organization:, event:, idempotency_key: nil)
         request = post_request(
@@ -38,8 +38,6 @@ module WorkOS
         )
 
         execute_request(request: request)
-
-        nil
       end
 
       # Create an Export of Audit Log Events.

--- a/lib/workos/audit_logs.rb
+++ b/lib/workos/audit_logs.rb
@@ -14,11 +14,7 @@ module WorkOS
       extend T::Sig
       include Client
 
-      # Create an Audit Log event.
-      #
-      # @param [String] organization An Organization ID
-      # @param [Hash] event An event hash
-      # @param [String] idempotency_key An idempotency key
+      # Create an Audit Log Event.
       sig do
         params(
           organization: String,
@@ -39,6 +35,58 @@ module WorkOS
         )
 
         execute_request(request: request)
+
+        nil
+      end
+
+      # Create an export of Audit Log Events.
+      sig do
+        params(
+          organization: String,
+          range_start: String,
+          range_end: String,
+          actions: T.nilable(T::Array[String]),
+          actors: T.nilable(T::Array[String]),
+          targets: T.nilable(T::Array[String]),
+        ).returns(WorkOS::AuditLogExport)
+      end
+      def create_export(organization:, range_start:, range_end:, actions: nil, actors: nil, targets: nil)
+        body = {
+          organization_id: organization,
+          range_start: range_start,
+          range_end: range_end,
+        }
+
+        body['actions'] = actions unless actions.nil?
+        body['actors'] = actors unless actors.nil?
+        body['targets'] = targets unless targets.nil?
+
+        request = post_request(
+          path: '/audit_logs/exports',
+          auth: true,
+          body: body,
+        )
+
+        response = execute_request(request: request)
+
+        WorkOS::AuditLogExport.new(response.body)
+      end
+
+      # Retreives an export of Audit Log Events
+      sig do
+        params(
+          id: String,
+        ).returns(WorkOS::AuditLogExport)
+      end
+      def get_export(id:)
+        request = get_request(
+          auth: true,
+          path: "/audit_logs/exports/#{id}",
+        )
+
+        response = execute_request(request: request)
+
+        WorkOS::AuditLogExport.new(response.body)
       end
     end
   end

--- a/lib/workos/audit_logs.rb
+++ b/lib/workos/audit_logs.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'net/http'
+require 'uri'
+
+module WorkOS
+  # The Audit Logs module provides convenience methods for working with the
+  # WorkOS Audit Logs platform. You'll need a valid API key.
+  #
+  # @see https://docs.workos.com/audit-logs/overview
+  module AuditLogs
+    class << self
+      extend T::Sig
+      include Client
+
+      # Create an Audit Log event.
+      #
+      # @param [String] organization An Organization ID
+      # @param [Hash] event An event hash
+      # @param [String] idempotency_key An idempotency key
+      sig do
+        params(
+          organization: String,
+          event: Hash,
+          idempotency_key: T.nilable(String),
+        ).returns(::T.untyped)
+      end
+
+      def create_event(organization:, event:, idempotency_key: nil)
+        request = post_request(
+          path: '/audit_logs/events',
+          auth: true,
+          idempotency_key: idempotency_key,
+          body: {
+            organization_id: organization,
+            event: event,
+          },
+        )
+
+        execute_request(request: request)
+      end
+    end
+  end
+end

--- a/lib/workos/audit_logs.rb
+++ b/lib/workos/audit_logs.rb
@@ -26,7 +26,6 @@ module WorkOS
           idempotency_key: T.nilable(String),
         ).returns(::T.untyped)
       end
-
       def create_event(organization:, event:, idempotency_key: nil)
         request = post_request(
           path: '/audit_logs/events',

--- a/lib/workos/audit_logs.rb
+++ b/lib/workos/audit_logs.rb
@@ -7,14 +7,18 @@ require 'uri'
 module WorkOS
   # The Audit Logs module provides convenience methods for working with the
   # WorkOS Audit Logs platform. You'll need a valid API key.
-  #
-  # @see https://docs.workos.com/audit-logs/overview
   module AuditLogs
     class << self
       extend T::Sig
       include Client
 
       # Create an Audit Log Event.
+      #
+      # @param [String] organization An Organization ID
+      # @param [Hash] event An Audit Log Event
+      # @param [String] idempotency_key An idempotency key
+      #
+      # @return [nil]
       sig do
         params(
           organization: String,
@@ -39,7 +43,16 @@ module WorkOS
         nil
       end
 
-      # Create an export of Audit Log Events.
+      # Create an Export of Audit Log Events.
+      #
+      # @param [String] organization An Organization ID
+      # @param [String] range_start ISO-8601 datetime
+      # @param [String] range_end ISO-8601 datetime
+      # @param [Array<String>] actions A list of actions to filter by
+      # @param [Array<String>] actors A list of actor names to filter by
+      # @param [Array<String>] targets A list of target types to filter by
+      #
+      # @return [WorkOS::AuditLogExport]
       sig do
         params(
           organization: String,
@@ -72,7 +85,11 @@ module WorkOS
         WorkOS::AuditLogExport.new(response.body)
       end
 
-      # Retreives an export of Audit Log Events
+      # Retrieves an Export of Audit Log Events
+      #
+      # @param [String] id An Audit Log Export ID
+      #
+      # @return [WorkOS::AuditLogExport]
       sig do
         params(
           id: String,

--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -138,6 +138,8 @@ module WorkOS
           message: json['message'],
           http_status: http_status,
           request_id: response['x-request-id'],
+          code: json['code'],
+          errors: json['errors'],
         )
       when 401
         raise AuthenticationError.new(

--- a/lib/workos/errors.rb
+++ b/lib/workos/errors.rb
@@ -12,6 +12,7 @@ module WorkOS
     attr_reader :code
     attr_reader :errors
 
+    # rubocop:disable Metrics/ParameterLists
     sig do
       params(
         message: T.nilable(String),
@@ -40,6 +41,7 @@ module WorkOS
       @code = code
       @errors = errors
     end
+    # rubocop:enable Metrics/ParameterLists
 
     sig { returns(String) }
     def to_s

--- a/lib/workos/errors.rb
+++ b/lib/workos/errors.rb
@@ -9,6 +9,8 @@ module WorkOS
 
     attr_reader :http_status
     attr_reader :request_id
+    attr_reader :code
+    attr_reader :errors
 
     sig do
       params(
@@ -18,7 +20,7 @@ module WorkOS
         http_status: T.nilable(Integer),
         request_id: T.nilable(String),
         code: T.nilable(String),
-        errors: T::Array[T::Hash],
+        errors: T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]),
       ).void
     end
     def initialize(

--- a/lib/workos/errors.rb
+++ b/lib/workos/errors.rb
@@ -18,15 +18,25 @@ module WorkOS
         http_status: T.nilable(Integer),
         request_id: T.nilable(String),
         code: T.nilable(String),
+        errors: T::Array[T::Hash],
       ).void
     end
-    def initialize(message: nil, error: nil, error_description: nil, http_status: nil, request_id: nil, code: nil)
+    def initialize(
+      message: nil,
+      error: nil,
+      error_description: nil,
+      http_status: nil,
+      request_id: nil,
+      code: nil,
+      errors: nil
+    )
       @message = message
       @error = error
       @error_description = error_description
       @http_status = http_status
       @request_id = request_id
       @code = code
+      @errors = errors
     end
 
     sig { returns(String) }

--- a/lib/workos/types.rb
+++ b/lib/workos/types.rb
@@ -5,6 +5,7 @@ module WorkOS
   # WorkOS believes strongly in typed languages,
   # so we're using Sorbet throughout this Ruby gem.
   module Types
+    require_relative 'types/audit_log_export_struct'
     require_relative 'types/connection_struct'
     require_relative 'types/directory_struct'
     require_relative 'types/directory_group_struct'

--- a/lib/workos/types/audit_log_export_struct.rb
+++ b/lib/workos/types/audit_log_export_struct.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# typed: strict
+
+module WorkOS
+  module Types
+    # This AuditLogExportStruct acts as a typed interface
+    # for the AuditLogExport class
+    class AuditLogExportStruct < T::Struct
+      const :object, String
+      const :id, String
+      const :state, String
+      const :url, T.nilable(String)
+      const :created_at, String
+      const :updated_at, String
+    end
+  end
+end

--- a/spec/lib/workos/audit_logs_spec.rb
+++ b/spec/lib/workos/audit_logs_spec.rb
@@ -101,7 +101,7 @@ describe WorkOS::AuditLogs do
             state: 'pending',
             url: nil,
             created_at: '2022-08-22T15:04:19.704Z',
-            updated_at: '2022-08-22T15:04:19.704Z'
+            updated_at: '2022-08-22T15:04:19.704Z',
           )
         end
       end

--- a/spec/lib/workos/audit_logs_spec.rb
+++ b/spec/lib/workos/audit_logs_spec.rb
@@ -4,6 +4,12 @@
 describe WorkOS::AuditLogs do
   it_behaves_like 'client'
 
+  before do
+    WorkOS.configure do |config|
+      config.key = 'example_api_key'
+    end
+  end
+
   describe '.create_event' do
     context 'with valid event payload' do
       let(:valid_event) do
@@ -42,9 +48,7 @@ describe WorkOS::AuditLogs do
               idempotency_key: 'idempotency_key',
             )
 
-            expect(response.code).to eq '201'
-            json = JSON.parse(response.body)
-            expect(json['success']).to be true
+            expect(response).to eq nil
           end
         end
       end
@@ -57,9 +61,7 @@ describe WorkOS::AuditLogs do
               event: valid_event,
             )
 
-            expect(response.code).to eq '201'
-            json = JSON.parse(response.body)
-            expect(json['success']).to be true
+            expect(response).to eq nil
           end
         end
       end
@@ -67,17 +69,76 @@ describe WorkOS::AuditLogs do
       context 'with invalid event' do
         it 'returns error' do
           VCR.use_cassette 'audit_logs/create_event_invalid', match_requests_on: %i[path body headers] do
-            expect do
-              described_class.create_event(
-                organization: 'org_123',
-                event: valid_event,
-              )
-            end.to raise_error(
-              WorkOS::InvalidRequestError,
-              /Status 400, Invalid Audit Log event./,
+            described_class.create_event(
+              organization: 'org_123',
+              event: valid_event,
             )
+          rescue WorkOS::InvalidRequestError => e
+            expect(e.message).to eq 'Status 400, Invalid Audit Log event - request ID: 1cf9b8e7-5910-4a6d-a333-46bcf841422e'
+            expect(e.code).to eq 'invalid_audit_log'
+            expect(e.errors.count).to eq 1
           end
         end
+      end
+    end
+  end
+
+  describe '.create_export' do
+    context 'without filters applied' do
+      it 'creates an event' do
+        VCR.use_cassette 'audit_logs/create_export', match_requests_on: %i[path body headers] do
+          audit_log_export = described_class.create_export(
+            organization: 'org_123',
+            range_start: '2022-06-22T15:04:19.704Z',
+            range_end: '2022-08-22T15:04:19.704Z',
+          )
+
+          expect(audit_log_export.object).to eq 'audit_log_export'
+          expect(audit_log_export.id).to eq 'audit_log_export_123'
+          expect(audit_log_export.state).to eq 'pending'
+          expect(audit_log_export.url).to eq nil
+          expect(audit_log_export.created_at).to eq '2022-08-22T15:04:19.704Z'
+          expect(audit_log_export.updated_at).to eq '2022-08-22T15:04:19.704Z'
+        end
+      end
+    end
+
+    context 'with filters applied' do
+      it 'creates an export' do
+        VCR.use_cassette 'audit_logs/create_export_with_filters', match_requests_on: %i[path body headers] do
+          audit_log_export = described_class.create_export(
+            organization: 'org_123',
+            range_start: '2022-06-22T15:04:19.704Z',
+            range_end: '2022-08-22T15:04:19.704Z',
+            actions: ['user.signed_in'],
+            actors: ['Jon Smith'],
+            targets: %w[user team],
+          )
+
+          expect(audit_log_export.object).to eq 'audit_log_export'
+          expect(audit_log_export.id).to eq 'audit_log_export_123'
+          expect(audit_log_export.state).to eq 'pending'
+          expect(audit_log_export.url).to eq nil
+          expect(audit_log_export.created_at).to eq '2022-08-22T15:04:19.704Z'
+          expect(audit_log_export.updated_at).to eq '2022-08-22T15:04:19.704Z'
+        end
+      end
+    end
+  end
+
+  describe '.get_export' do
+    it 'returns an export' do
+      VCR.use_cassette 'audit_logs/get_export', match_requests_on: %i[path headers] do
+        audit_log_export = described_class.get_export(
+          id: 'audit_log_export_123',
+        )
+
+        expect(audit_log_export.object).to eq 'audit_log_export'
+        expect(audit_log_export.id).to eq 'audit_log_export_123'
+        expect(audit_log_export.state).to eq 'ready'
+        expect(audit_log_export.url).to eq 'https://audit-logs.com/download.csv'
+        expect(audit_log_export.created_at).to eq '2022-08-22T15:04:19.704Z'
+        expect(audit_log_export.updated_at).to eq '2022-08-22T15:04:19.704Z'
       end
     end
   end

--- a/spec/lib/workos/audit_logs_spec.rb
+++ b/spec/lib/workos/audit_logs_spec.rb
@@ -74,7 +74,9 @@ describe WorkOS::AuditLogs do
               event: valid_event,
             )
           rescue WorkOS::InvalidRequestError => e
-            expect(e.message).to eq 'Status 400, Invalid Audit Log event - request ID: 1cf9b8e7-5910-4a6d-a333-46bcf841422e'
+            expect(
+              e.message,
+            ).to eq 'Status 400, Invalid Audit Log event - request ID: 1cf9b8e7-5910-4a6d-a333-46bcf841422e'
             expect(e.code).to eq 'invalid_audit_log'
             expect(e.errors.count).to eq 1
           end

--- a/spec/lib/workos/audit_logs_spec.rb
+++ b/spec/lib/workos/audit_logs_spec.rb
@@ -41,7 +41,7 @@ describe WorkOS::AuditLogs do
 
       context 'with idempotency key' do
         it 'creates an event' do
-          VCR.use_cassette 'audit_logs/create_event_custom_idempotency_key', match_requests_on: %i[path body headers] do
+          VCR.use_cassette 'audit_logs/create_event_custom_idempotency_key', match_requests_on: %i[path body] do
             response = described_class.create_event(
               organization: 'org_123',
               event: valid_event,
@@ -55,7 +55,7 @@ describe WorkOS::AuditLogs do
 
       context 'without idempotency key' do
         it 'creates an event' do
-          VCR.use_cassette 'audit_logs/create_event', match_requests_on: %i[path body headers] do
+          VCR.use_cassette 'audit_logs/create_event', match_requests_on: %i[path body] do
             response = described_class.create_event(
               organization: 'org_123',
               event: valid_event,
@@ -68,7 +68,7 @@ describe WorkOS::AuditLogs do
 
       context 'with invalid event' do
         it 'returns error' do
-          VCR.use_cassette 'audit_logs/create_event_invalid', match_requests_on: %i[path body headers] do
+          VCR.use_cassette 'audit_logs/create_event_invalid', match_requests_on: %i[path body] do
             described_class.create_event(
               organization: 'org_123',
               event: valid_event,
@@ -88,7 +88,7 @@ describe WorkOS::AuditLogs do
   describe '.create_export' do
     context 'without filters applied' do
       it 'creates an event' do
-        VCR.use_cassette 'audit_logs/create_export', match_requests_on: %i[path body headers] do
+        VCR.use_cassette 'audit_logs/create_export', match_requests_on: %i[path body] do
           audit_log_export = described_class.create_export(
             organization: 'org_123',
             range_start: '2022-06-22T15:04:19.704Z',
@@ -107,7 +107,7 @@ describe WorkOS::AuditLogs do
 
     context 'with filters applied' do
       it 'creates an export' do
-        VCR.use_cassette 'audit_logs/create_export_with_filters', match_requests_on: %i[path body headers] do
+        VCR.use_cassette 'audit_logs/create_export_with_filters', match_requests_on: %i[path body] do
           audit_log_export = described_class.create_export(
             organization: 'org_123',
             range_start: '2022-06-22T15:04:19.704Z',
@@ -130,7 +130,7 @@ describe WorkOS::AuditLogs do
 
   describe '.get_export' do
     it 'returns an export' do
-      VCR.use_cassette 'audit_logs/get_export', match_requests_on: %i[path headers] do
+      VCR.use_cassette 'audit_logs/get_export', match_requests_on: %i[path] do
         audit_log_export = described_class.get_export(
           id: 'audit_log_export_123',
         )

--- a/spec/lib/workos/audit_logs_spec.rb
+++ b/spec/lib/workos/audit_logs_spec.rb
@@ -48,7 +48,7 @@ describe WorkOS::AuditLogs do
               idempotency_key: 'idempotency_key',
             )
 
-            expect(response).to eq nil
+            expect(response).to eq T::Private::Types::Void::VOID
           end
         end
       end
@@ -61,7 +61,7 @@ describe WorkOS::AuditLogs do
               event: valid_event,
             )
 
-            expect(response).to eq nil
+            expect(response).to eq T::Private::Types::Void::VOID
           end
         end
       end

--- a/spec/lib/workos/audit_logs_spec.rb
+++ b/spec/lib/workos/audit_logs_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+# typed: false
+
+describe WorkOS::AuditLogs do
+  it_behaves_like 'client'
+
+  describe '.create_event' do
+    context 'with valid event payload' do
+      let(:valid_event) do
+        {
+          action: 'user.signed_in',
+          occurred_at: '2022-08-22T15:04:19.704Z',
+          actor: {
+            id: 'user_123',
+            type: 'user',
+            name: 'User',
+            metadata: {
+              foo: 'bar',
+            },
+          },
+          targets: [{
+            id: 'team_123',
+            type: 'team',
+            name: 'Team',
+            metadata: {
+              foo: 'bar',
+            },
+          }],
+          context: {
+            location: '1.1.1.1',
+            user_agent: 'Mozilla',
+          },
+        }
+      end
+
+      context 'with idempotency key' do
+        it 'creates an event' do
+          VCR.use_cassette 'audit_logs/create_event_custom_idempotency_key', match_requests_on: %i[path body headers] do
+            response = described_class.create_event(
+              organization: 'org_123',
+              event: valid_event,
+              idempotency_key: 'idempotency_key',
+            )
+
+            expect(response.code).to eq '201'
+            json = JSON.parse(response.body)
+            expect(json['success']).to be true
+          end
+        end
+      end
+
+      context 'without idempotency key' do
+        it 'creates an event' do
+          VCR.use_cassette 'audit_logs/create_event', match_requests_on: %i[path body headers] do
+            response = described_class.create_event(
+              organization: 'org_123',
+              event: valid_event,
+            )
+
+            expect(response.code).to eq '201'
+            json = JSON.parse(response.body)
+            expect(json['success']).to be true
+          end
+        end
+      end
+
+      context 'with invalid event' do
+        it 'returns error' do
+          VCR.use_cassette 'audit_logs/create_event_invalid', match_requests_on: %i[path body headers] do
+            expect do
+              described_class.create_event(
+                organization: 'org_123',
+                event: valid_event,
+              )
+            end.to raise_error(
+              WorkOS::InvalidRequestError,
+              /Status 400, Invalid Audit Log event./,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/workos/audit_logs_spec.rb
+++ b/spec/lib/workos/audit_logs_spec.rb
@@ -95,12 +95,14 @@ describe WorkOS::AuditLogs do
             range_end: '2022-08-22T15:04:19.704Z',
           )
 
-          expect(audit_log_export.object).to eq 'audit_log_export'
-          expect(audit_log_export.id).to eq 'audit_log_export_123'
-          expect(audit_log_export.state).to eq 'pending'
-          expect(audit_log_export.url).to eq nil
-          expect(audit_log_export.created_at).to eq '2022-08-22T15:04:19.704Z'
-          expect(audit_log_export.updated_at).to eq '2022-08-22T15:04:19.704Z'
+          expect(audit_log_export).to have_attributes(
+            object: 'audit_log_export',
+            id: 'audit_log_export_123',
+            state: 'pending',
+            url: nil,
+            created_at: '2022-08-22T15:04:19.704Z',
+            updated_at: '2022-08-22T15:04:19.704Z'
+          )
         end
       end
     end

--- a/spec/support/fixtures/vcr_cassettes/audit_logs/create_event.yml
+++ b/spec/support/fixtures/vcr_cassettes/audit_logs/create_event.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.workos.com/audit_logs/events
+      body:
+        encoding: UTF-8
+        string: '{"organization_id":"org_123","event":{"action":"user.signed_in","occurred_at":"2022-08-22T15:04:19.704Z","actor":{"id":"user_123","type":"user","name":"User","metadata":{"foo":"bar"}},"targets":[{"id":"team_123","type":"team","name":"Team","metadata":{"foo":"bar"}}],"context":{"location":"1.1.1.1","user_agent":"Mozilla"}}}'
+      headers:
+        Content-Type: "application/json"
+        Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+        Accept: "*/*"
+        User-Agent: "WorkOS; ruby/3.0.2; x86_64-darwin21; v2.5.1"
+        Authorization: "Bearer "
+    response:
+      status:
+        code: 201
+        message: Created
+      headers:
+        Server:
+          - Cowboy
+        Connection:
+          - keep-alive
+        Access-Control-Allow-Origin:
+          - https://dashboard.workos.com
+        Vary:
+          - Origin, Accept-Encoding
+        Access-Control-Allow-Credentials:
+          - "true"
+        X-Dns-Prefetch-Control:
+          - "off"
+        X-Frame-Options:
+          - SAMEORIGIN
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        X-Download-Options:
+          - noopen
+        X-Content-Type-Options:
+          - nosniff
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Request-Id:
+          - 1cf9b8e7-5910-4a6d-a333-46bcf841422e
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "16"
+        Etag:
+          - W/"10-oV4hJxRVSENxc/wX8+mA4/Pe4tA"
+        Date:
+          - Sat, 11 Jan 2020 04:22:48 GMT
+        Via:
+          - 1.1 vegur
+      body:
+        encoding: UTF-8
+        string: '{"success":true}'
+      http_version:
+    recorded_at: Sat, 11 Jan 2020 04:22:48 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/audit_logs/create_event.yml
+++ b/spec/support/fixtures/vcr_cassettes/audit_logs/create_event.yml
@@ -11,7 +11,7 @@ http_interactions:
         Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
         Accept: "*/*"
         User-Agent: "WorkOS; ruby/3.0.2; x86_64-darwin21; v2.5.1"
-        Authorization: "Bearer "
+        Authorization: "Bearer example_api_key"
     response:
       status:
         code: 201

--- a/spec/support/fixtures/vcr_cassettes/audit_logs/create_event_custom_idempotency_key.yml
+++ b/spec/support/fixtures/vcr_cassettes/audit_logs/create_event_custom_idempotency_key.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.workos.com/audit_logs/events
+      body:
+        encoding: UTF-8
+        string: '{"organization_id":"org_123","event":{"action":"user.signed_in","occurred_at":"2022-08-22T15:04:19.704Z","actor":{"id":"user_123","type":"user","name":"User","metadata":{"foo":"bar"}},"targets":[{"id":"team_123","type":"team","name":"Team","metadata":{"foo":"bar"}}],"context":{"location":"1.1.1.1","user_agent":"Mozilla"}}}'
+      headers:
+        Content-Type: "application/json"
+        Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+        Accept: "*/*"
+        User-Agent: "WorkOS; ruby/3.0.2; x86_64-darwin21; v2.5.1"
+        Authorization: "Bearer "
+        Idempotency-Key: "idempotency_key"
+    response:
+      status:
+        code: 201
+        message: Created
+      headers:
+        Server:
+          - Cowboy
+        Connection:
+          - keep-alive
+        Access-Control-Allow-Origin:
+          - https://dashboard.workos.com
+        Vary:
+          - Origin, Accept-Encoding
+        Access-Control-Allow-Credentials:
+          - "true"
+        X-Dns-Prefetch-Control:
+          - "off"
+        X-Frame-Options:
+          - SAMEORIGIN
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        X-Download-Options:
+          - noopen
+        X-Content-Type-Options:
+          - nosniff
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Request-Id:
+          - 1cf9b8e7-5910-4a6d-a333-46bcf841422e
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "16"
+        Etag:
+          - W/"10-oV4hJxRVSENxc/wX8+mA4/Pe4tA"
+        Date:
+          - Sat, 11 Jan 2020 04:22:48 GMT
+        Via:
+          - 1.1 vegur
+      body:
+        encoding: UTF-8
+        string: '{"success":true}'
+      http_version:
+    recorded_at: Sat, 11 Jan 2020 04:22:48 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/audit_logs/create_event_custom_idempotency_key.yml
+++ b/spec/support/fixtures/vcr_cassettes/audit_logs/create_event_custom_idempotency_key.yml
@@ -11,7 +11,7 @@ http_interactions:
         Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
         Accept: "*/*"
         User-Agent: "WorkOS; ruby/3.0.2; x86_64-darwin21; v2.5.1"
-        Authorization: "Bearer "
+        Authorization: "Bearer example_api_key"
         Idempotency-Key: "idempotency_key"
     response:
       status:

--- a/spec/support/fixtures/vcr_cassettes/audit_logs/create_event_invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/audit_logs/create_event_invalid.yml
@@ -11,11 +11,11 @@ http_interactions:
         Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
         Accept: "*/*"
         User-Agent: "WorkOS; ruby/3.0.2; x86_64-darwin21; v2.5.1"
-        Authorization: "Bearer "
+        Authorization: "Bearer example_api_key"
     response:
       status:
         code: 400
-        message: Created
+        message: Bad Request
       headers:
         Server:
           - Cowboy

--- a/spec/support/fixtures/vcr_cassettes/audit_logs/create_event_invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/audit_logs/create_event_invalid.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.workos.com/audit_logs/events
+      body:
+        encoding: UTF-8
+        string: '{"organization_id":"org_123","event":{"action":"user.signed_in","occurred_at":"2022-08-22T15:04:19.704Z","actor":{"id":"user_123","type":"user","name":"User","metadata":{"foo":"bar"}},"targets":[{"id":"team_123","type":"team","name":"Team","metadata":{"foo":"bar"}}],"context":{"location":"1.1.1.1","user_agent":"Mozilla"}}}'
+      headers:
+        Content-Type: "application/json"
+        Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+        Accept: "*/*"
+        User-Agent: "WorkOS; ruby/3.0.2; x86_64-darwin21; v2.5.1"
+        Authorization: "Bearer "
+    response:
+      status:
+        code: 400
+        message: Created
+      headers:
+        Server:
+          - Cowboy
+        Connection:
+          - keep-alive
+        Access-Control-Allow-Origin:
+          - https://dashboard.workos.com
+        Vary:
+          - Origin, Accept-Encoding
+        Access-Control-Allow-Credentials:
+          - "true"
+        X-Dns-Prefetch-Control:
+          - "off"
+        X-Frame-Options:
+          - SAMEORIGIN
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        X-Download-Options:
+          - noopen
+        X-Content-Type-Options:
+          - nosniff
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Request-Id:
+          - 1cf9b8e7-5910-4a6d-a333-46bcf841422e
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "16"
+        Etag:
+          - W/"10-oV4hJxRVSENxc/wX8+mA4/Pe4tA"
+        Date:
+          - Sat, 11 Jan 2020 04:22:48 GMT
+        Via:
+          - 1.1 vegur
+      body:
+        encoding: UTF-8
+        string: '{"code":"invalid_audit_log","message":"Invalid Audit Log event","errors":[{"instancePath":"/targets/0/type","schemaPath":"#/properties/targets/allOf/0/contains/properties/type/const","keyword":"const","params":{"allowValues":["team"]},"message":"must be equal to constant","schema":"team","parentSchema":{"enum":["team"],"type":"string"},"data":"user"}]}'
+      http_version:
+    recorded_at: Sat, 11 Jan 2020 04:22:48 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/audit_logs/create_export.yml
+++ b/spec/support/fixtures/vcr_cassettes/audit_logs/create_export.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.workos.com/audit_logs/exports
+      body:
+        encoding: UTF-8
+        string: '{"organization_id":"org_123","range_start":"2022-06-22T15:04:19.704Z","range_end":"2022-08-22T15:04:19.704Z"}'
+      headers:
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - WorkOS; ruby/3.0.2; x86_64-darwin21; v2.5.1
+        Authorization:
+          - "Bearer example_api_key"
+    response:
+      status:
+        code: 201
+        message: Created
+      headers:
+        Date:
+          - Mon, 22 Aug 2022 17:47:49 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "26"
+        Connection:
+          - keep-alive
+        Cf-Ray:
+          - 73ed6f92c9161847-ATL
+        Etag:
+          - W/"1a-pljHtlo127JYJR4E/RYOPb6ucbw"
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        Vary:
+          - Origin, Accept-Encoding
+        Via:
+          - 1.1 spaces-router (a302eeabfffb)
+        Cf-Cache-Status:
+          - DYNAMIC
+        Access-Control-Allow-Credentials:
+          - "true"
+        Content-Security-Policy:
+          - "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self'
+            https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src
+            'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+        Expect-Ct:
+          - max-age=0
+        Referrer-Policy:
+          - no-referrer
+        X-Content-Type-Options:
+          - nosniff
+        X-Dns-Prefetch-Control:
+          - "off"
+        X-Download-Options:
+          - noopen
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Request-Id:
+          - eb09b349-08f4-b79b-ccb2-87fa4609c1ee
+        X-Xss-Protection:
+          - "0"
+        Server:
+          - cloudflare
+      body:
+        encoding: UTF-8
+        string: '{"object":"audit_log_export","id":"audit_log_export_123","state":"pending","created_at":"2022-08-22T15:04:19.704Z","updated_at":"2022-08-22T15:04:19.704Z"}'
+      http_version:
+    recorded_at: Mon, 22 Aug 2022 17:47:49 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/audit_logs/create_export_with_filters.yml
+++ b/spec/support/fixtures/vcr_cassettes/audit_logs/create_export_with_filters.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.workos.com/audit_logs/exports
+      body:
+        encoding: UTF-8
+        string:
+          '{"organization_id":"org_123","range_start":"2022-06-22T15:04:19.704Z","range_end":"2022-08-22T15:04:19.704Z","actions":["user.signed_in"],"actors":["Jon
+          Smith"],"targets":["user","team"]}'
+      headers:
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - WorkOS; ruby/3.0.2; x86_64-darwin21; v2.5.1
+        Authorization:
+          - "Bearer example_api_key"
+    response:
+      status:
+        code: 201
+        message: Created
+      headers:
+        Date:
+          - Mon, 22 Aug 2022 17:47:49 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "26"
+        Connection:
+          - keep-alive
+        Cf-Ray:
+          - 73ed6f92c9161847-ATL
+        Etag:
+          - W/"1a-pljHtlo127JYJR4E/RYOPb6ucbw"
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        Vary:
+          - Origin, Accept-Encoding
+        Via:
+          - 1.1 spaces-router (a302eeabfffb)
+        Cf-Cache-Status:
+          - DYNAMIC
+        Access-Control-Allow-Credentials:
+          - "true"
+        Content-Security-Policy:
+          - "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self'
+            https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src
+            'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+        Expect-Ct:
+          - max-age=0
+        Referrer-Policy:
+          - no-referrer
+        X-Content-Type-Options:
+          - nosniff
+        X-Dns-Prefetch-Control:
+          - "off"
+        X-Download-Options:
+          - noopen
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Request-Id:
+          - eb09b349-08f4-b79b-ccb2-87fa4609c1ee
+        X-Xss-Protection:
+          - "0"
+        Server:
+          - cloudflare
+      body:
+        encoding: UTF-8
+        string: '{"object":"audit_log_export","id":"audit_log_export_123","state":"pending","created_at":"2022-08-22T15:04:19.704Z","updated_at":"2022-08-22T15:04:19.704Z"}'
+      http_version:
+    recorded_at: Mon, 22 Aug 2022 17:47:49 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/audit_logs/get_export.yml
+++ b/spec/support/fixtures/vcr_cassettes/audit_logs/get_export.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://api.workos.com/audit_logs/exports/audit_log_export_123
+      headers:
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - WorkOS; ruby/3.0.2; x86_64-darwin21; v2.5.1
+        Authorization:
+          - "Bearer example_api_key"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Mon, 22 Aug 2022 17:47:49 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "26"
+        Connection:
+          - keep-alive
+        Cf-Ray:
+          - 73ed6f92c9161847-ATL
+        Etag:
+          - W/"1a-pljHtlo127JYJR4E/RYOPb6ucbw"
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        Vary:
+          - Origin, Accept-Encoding
+        Via:
+          - 1.1 spaces-router (a302eeabfffb)
+        Cf-Cache-Status:
+          - DYNAMIC
+        Access-Control-Allow-Credentials:
+          - "true"
+        Content-Security-Policy:
+          - "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self'
+            https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src
+            'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+        Expect-Ct:
+          - max-age=0
+        Referrer-Policy:
+          - no-referrer
+        X-Content-Type-Options:
+          - nosniff
+        X-Dns-Prefetch-Control:
+          - "off"
+        X-Download-Options:
+          - noopen
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Request-Id:
+          - eb09b349-08f4-b79b-ccb2-87fa4609c1ee
+        X-Xss-Protection:
+          - "0"
+        Server:
+          - cloudflare
+      body:
+        encoding: UTF-8
+        string: '{"object":"audit_log_export","id":"audit_log_export_123","state":"ready","url":"https://audit-logs.com/download.csv","created_at":"2022-08-22T15:04:19.704Z","updated_at":"2022-08-22T15:04:19.704Z"}'
+      http_version:
+    recorded_at: Mon, 22 Aug 2022 17:47:49 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
Adds `create_event`, `create_export` and `get_export` methods.

Note: currently includes the changes from https://github.com/workos/workos-ruby/pull/174