### PR TITLE
Bump version to v2.11.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (2.10.0)
+    workos (2.11.0)
       sorbet-runtime (~> 0.5)
 
 GEM

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '2.10.0'
+  VERSION = '2.11.0'
 end


### PR DESCRIPTION
## Description

Bump the gem version to 2.11.0.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
