### PR TITLE
Add Generic Default Error to Response Handler

### DIFF
--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -165,6 +165,12 @@ module WorkOS
           request_id: response['x-request-id'],
           code: code,
         )
+      else
+        raise APIError.new(
+          message: json['message'],
+          http_status: http_status,
+          request_id: response['x-request-id'],
+        )
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize


### PR DESCRIPTION
## Description
Resolves https://github.com/workos/workos-ruby/issues/190
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
