### PR TITLE
add `actor_ids` param to `create_export`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ Layout/LineLength:
 Metrics/BlockLength:
   ExcludedMethods: ['describe', 'context', 'before']
 Metrics/MethodLength:
-  Max: 15
+  Max: 30
 Metrics/ModuleLength:
   Max: 200
 Metrics/ParameterLists:

--- a/lib/workos/audit_logs.rb
+++ b/lib/workos/audit_logs.rb
@@ -59,13 +59,13 @@ module WorkOS
           range_end: String,
           actions: T.nilable(T::Array[String]),
           actors: T.nilable(T::Array[String]),
+          targets: T.nilable(T::Array[String]),
           actor_names: T.nilable(T::Array[String]),
           actor_ids: T.nilable(T::Array[String]),
-          targets: T.nilable(T::Array[String]),
         ).returns(WorkOS::AuditLogExport)
       end
       def create_export(organization:, range_start:, range_end:, actions: nil, # rubocop:disable Metrics/ParameterLists
-                        actors: nil, actor_names: nil, actor_ids: nil, targets: nil)
+                        actors: nil, targets: nil, actor_names: nil, actor_ids: nil)
         body = {
           organization_id: organization,
           range_start: range_start,

--- a/lib/workos/audit_logs.rb
+++ b/lib/workos/audit_logs.rb
@@ -64,7 +64,8 @@ module WorkOS
           targets: T.nilable(T::Array[String]),
         ).returns(WorkOS::AuditLogExport)
       end
-      def create_export(organization:, range_start:, range_end:, actions: nil, actors: nil, actor_names: nil, actor_ids: nil, targets: nil)
+      def create_export(organization:, range_start:, range_end:, actions: nil, # rubocop:disable Metrics/ParameterLists
+                        actors: nil, actor_names: nil, actor_ids: nil, targets: nil)
         body = {
           organization_id: organization,
           range_start: range_start,

--- a/lib/workos/audit_logs.rb
+++ b/lib/workos/audit_logs.rb
@@ -46,7 +46,9 @@ module WorkOS
       # @param [String] range_start ISO-8601 datetime
       # @param [String] range_end ISO-8601 datetime
       # @param [Array<String>] actions A list of actions to filter by
-      # @param [Array<String>] actors A list of actor names to filter by
+      # @param [Array<String>] @deprecated use `actor_names` instead
+      # @param [Array<String>] actor_names A list of actor names to filter by
+      # @param [Array<String>] actor_ids A list of actor ids to filter by
       # @param [Array<String>] targets A list of target types to filter by
       #
       # @return [WorkOS::AuditLogExport]
@@ -57,10 +59,12 @@ module WorkOS
           range_end: String,
           actions: T.nilable(T::Array[String]),
           actors: T.nilable(T::Array[String]),
+          actor_names: T.nilable(T::Array[String]),
+          actor_ids: T.nilable(T::Array[String]),
           targets: T.nilable(T::Array[String]),
         ).returns(WorkOS::AuditLogExport)
       end
-      def create_export(organization:, range_start:, range_end:, actions: nil, actors: nil, targets: nil)
+      def create_export(organization:, range_start:, range_end:, actions: nil, actors: nil, actor_names: nil, actor_ids: nil, targets: nil)
         body = {
           organization_id: organization,
           range_start: range_start,
@@ -69,6 +73,8 @@ module WorkOS
 
         body['actions'] = actions unless actions.nil?
         body['actors'] = actors unless actors.nil?
+        body['actor_names'] = actor_names unless actor_names.nil?
+        body['actor_ids'] = actor_ids unless actor_ids.nil?
         body['targets'] = targets unless targets.nil?
 
         request = post_request(

--- a/lib/workos/directory_user.rb
+++ b/lib/workos/directory_user.rb
@@ -13,7 +13,7 @@ module WorkOS
                   :groups, :custom_attributes, :raw_attributes, :directory_id, :organization_id,
                   :created_at, :updated_at
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     sig { params(json: String).void }
     def initialize(json)
       raw = parse_json(json)
@@ -36,9 +36,8 @@ module WorkOS
 
       replace_without_warning(to_json)
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
-    # rubocop:disable Metrics/MethodLength
     def to_json(*)
       {
         id: id,
@@ -58,7 +57,6 @@ module WorkOS
         updated_at: updated_at,
       }
     end
-    # rubocop:enable Metrics/MethodLength
 
     def primary_email
       primary_email = (emails || []).find { |email| email[:primary] }
@@ -67,7 +65,7 @@ module WorkOS
 
     private
 
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize
     sig do
       params(
         json_string: String,
@@ -94,6 +92,6 @@ module WorkOS
         raw_attributes: hash[:raw_attributes],
       )
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/lib/workos/mfa.rb
+++ b/lib/workos/mfa.rb
@@ -76,7 +76,6 @@ module WorkOS
           phone_number: T.nilable(String),
         ).returns(WorkOS::Factor)
       end
-      # rubocop:disable Metrics/MethodLength
       def enroll_factor(
         type:,
         totp_issuer: nil,
@@ -101,7 +100,6 @@ module WorkOS
         ))
         WorkOS::Factor.new(response.body)
       end
-      # rubocop:enable Metrics/MethodLength
 
       sig do
         params(

--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -54,7 +54,7 @@ module WorkOS
       #      "response_type=code&state=%7B%3Anext_page%3D%3E%22%2Fdocs%22%7D"
       #
       # @return [String]
-      # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+      # rubocop:disable Metrics/ParameterLists
       sig do
         params(
           redirect_uri: String,
@@ -106,7 +106,7 @@ module WorkOS
 
         "https://#{WorkOS::API_HOSTNAME}/sso/authorize?#{query}"
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
+      # rubocop:enable Metrics/ParameterLists
 
       sig do
         params(
@@ -271,7 +271,6 @@ module WorkOS
       end
 
       sig { params(response: Net::HTTPResponse).void }
-      # rubocop:disable Metrics/MethodLength
       def check_and_raise_profile_and_token_error(response:)
         begin
           body = JSON.parse(response.body)
@@ -293,7 +292,6 @@ module WorkOS
           request_id: request_id,
         )
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/workos/webhooks.rb
+++ b/lib/workos/webhooks.rb
@@ -82,7 +82,7 @@ module WorkOS
           tolerance: Integer,
         ).returns(T::Boolean)
       end
-      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:disable Metrics/AbcSize
       def verify_header(
         payload:,
         sig_header:,
@@ -120,7 +120,7 @@ module WorkOS
 
         true
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:enable Metrics/AbcSize
 
       # Extracts timestamp and signature hash from WorkOS-Signature header
       #

--- a/spec/lib/workos/audit_logs_spec.rb
+++ b/spec/lib/workos/audit_logs_spec.rb
@@ -116,6 +116,8 @@ describe WorkOS::AuditLogs do
             range_end: '2022-08-22T15:04:19.704Z',
             actions: ['user.signed_in'],
             actors: ['Jon Smith'],
+            actor_names: ['Jon Smith'],
+            actor_ids: ['user_123'],
             targets: %w[user team],
           )
 

--- a/spec/support/fixtures/vcr_cassettes/audit_logs/create_export_with_filters.yml
+++ b/spec/support/fixtures/vcr_cassettes/audit_logs/create_export_with_filters.yml
@@ -6,8 +6,7 @@ http_interactions:
       body:
         encoding: UTF-8
         string:
-          '{"organization_id":"org_123","range_start":"2022-06-22T15:04:19.704Z","range_end":"2022-08-22T15:04:19.704Z","actions":["user.signed_in"],"actors":["Jon
-          Smith"],"targets":["user","team"]}'
+          '{"organization_id":"org_123","range_start":"2022-06-22T15:04:19.704Z","range_end":"2022-08-22T15:04:19.704Z","actions":["user.signed_in"],"actors":["Jon Smith"],"actor_names":["Jon Smith"],"actor_ids":["user_123"],"targets":["user","team"]}'
       headers:
         Content-Type:
           - application/json


### PR DESCRIPTION
## Description

Adds `actor_ids` / `actor_names` and deprecates `actors`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
