### PR TITLE
Use snake case for Events range params

### DIFF
--- a/spec/lib/workos/event_spec.rb
+++ b/spec/lib/workos/event_spec.rb
@@ -62,10 +62,10 @@ describe WorkOS::Events do
       end
     end
 
-    context 'with the rangeStart and rangeEnd options' do
+    context 'with the range_start and range_end options' do
       it 'forms the proper request to the API' do
         request_args = [
-          '/events?rangeStart=2023-01-01T00%3A00%3A00Z&rangeEnd=2023-01-03T00%3A00%3A00Z',
+          '/events?range_start=2023-01-01T00%3A00%3A00Z&range_end=2023-01-03T00%3A00%3A00Z',
           'Content-Type' => 'application/json'
         ]
 
@@ -76,8 +76,8 @@ describe WorkOS::Events do
 
         VCR.use_cassette 'events/list_events_with_range' do
           events = described_class.list_events(
-            rangeStart: '2023-01-01T00:00:00Z',
-            rangeEnd: '2023-01-03T00:00:00Z',
+            range_start: '2023-01-01T00:00:00Z',
+            range_end: '2023-01-03T00:00:00Z',
           )
 
           expect(events.data.size).to eq(1)

--- a/spec/support/fixtures/vcr_cassettes/events/list_events_with_range.yml
+++ b/spec/support/fixtures/vcr_cassettes/events/list_events_with_range.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.workos.com/events?rangeEnd=2023-01-03T00:00:00Z&rangeStart=2023-01-01T00:00:00Z
+    uri: https://api.workos.com/events?range_end=2023-01-03T00:00:00Z&range_start=2023-01-01T00:00:00Z
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
## Description
Use snake case for range params in the Events API. This makes Events consistent with the rest of our API.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
