### PR TITLE
Update version to v2.15.0

### DIFF
--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '2.14.0'
+  VERSION = '2.15.0'
 end


### PR DESCRIPTION
## Description
* Changed the Events API (in beta) `rangeStart` and `rangeEnd` parameters to `range_start` and `range_end` (https://github.com/workos/workos-ruby/pull/200).
* Added `actor_ids`, and `actor_names` parameters to `auditLogs.createExport` method, deprecated `actors` (https://github.com/workos/workos-ruby/pull/197).

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
