### PR TITLE
Lazily load configuration env vars

### DIFF
--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -11,10 +11,25 @@ require 'workos/configuration'
 # requests to the WorkOS API. The gem will read
 # your API key automatically from the ENV var `WORKOS_API_KEY`.
 # Alternatively, you can set the key yourself with
-# `WorkOS.key = [your api key]` somewhere in the load path of
-# your application, such as an initializer.
+# `WorkOS.configure { |config| config.key = [your api key] }` somewhere
+# in the load path of your application, such as an initializer.
 module WorkOS
-  API_HOSTNAME = ENV['WORKOS_API_HOSTNAME'] || 'api.workos.com'
+  def self.default_config
+    Configuration.new.tap do |config|
+      config.api_hostname = ENV['WORKOS_API_HOSTNAME'] || 'api.workos.com'
+      # Remove WORKOS_KEY at some point in the future. Keeping it here now for
+      # backwards compatibility.
+      config.key = ENV['WORKOS_API_KEY'] || ENV['WORKOS_KEY']
+    end
+  end
+
+  def self.config
+    @config ||= default_config
+  end
+
+  def self.configure
+    yield(config)
+  end
 
   def self.key=(value)
     warn '`WorkOS.key=` is deprecated. Use `WorkOS.configure` instead.'
@@ -26,14 +41,6 @@ module WorkOS
     warn '`WorkOS.key` is deprecated. Use `WorkOS.configure` instead.'
 
     config.key
-  end
-
-  def self.config
-    @config ||= Configuration.new
-  end
-
-  def self.configure
-    yield(config)
   end
 
   autoload :Types, 'workos/types'
@@ -71,9 +78,4 @@ module WorkOS
   autoload :InvalidRequestError, 'workos/errors'
   autoload :SignatureVerificationError, 'workos/errors'
   autoload :TimeoutError, 'workos/errors'
-
-  # Remove WORKOS_KEY at some point in the future. Keeping it here now for
-  # backwards compatibility.
-  key = ENV['WORKOS_API_KEY'] || ENV['WORKOS_KEY']
-  config.key = key unless key.nil?
 end

--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -9,7 +9,7 @@ module WorkOS
 
     sig { returns(Net::HTTP) }
     def client
-      Net::HTTP.new(WorkOS::API_HOSTNAME, 443).tap do |http_client|
+      Net::HTTP.new(WorkOS.config.api_hostname, 443).tap do |http_client|
         http_client.use_ssl = true
         http_client.open_timeout = WorkOS.config.timeout
         http_client.read_timeout = WorkOS.config.timeout

--- a/lib/workos/configuration.rb
+++ b/lib/workos/configuration.rb
@@ -4,7 +4,7 @@
 module WorkOS
   # Configuration class sets config initializer
   class Configuration
-    attr_accessor :timeout, :key
+    attr_accessor :api_hostname, :timeout, :key
 
     def initialize
       @timeout = 60

--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -104,7 +104,7 @@ module WorkOS
           organization: organization,
         }.compact)
 
-        "https://#{WorkOS::API_HOSTNAME}/sso/authorize?#{query}"
+        "https://#{WorkOS.config.api_hostname}/sso/authorize?#{query}"
       end
       # rubocop:enable Metrics/ParameterLists
 

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -26,7 +26,7 @@ describe WorkOS::SSO do
       it 'returns the expected hostname' do
         authorization_url = described_class.authorization_url(**args)
 
-        expect(URI.parse(authorization_url).host).to eq(WorkOS::API_HOSTNAME)
+        expect(URI.parse(authorization_url).host).to eq(WorkOS.config.api_hostname)
       end
 
       it 'returns the expected query string' do
@@ -60,7 +60,7 @@ describe WorkOS::SSO do
       it 'returns the expected hostname' do
         authorization_url = described_class.authorization_url(**args)
 
-        expect(URI.parse(authorization_url).host).to eq(WorkOS::API_HOSTNAME)
+        expect(URI.parse(authorization_url).host).to eq(WorkOS.config.api_hostname)
       end
 
       it 'returns the expected query string' do
@@ -94,7 +94,7 @@ describe WorkOS::SSO do
       it 'returns the expected hostname' do
         authorization_url = described_class.authorization_url(**args)
 
-        expect(URI.parse(authorization_url).host).to eq(WorkOS::API_HOSTNAME)
+        expect(URI.parse(authorization_url).host).to eq(WorkOS.config.api_hostname)
       end
 
       it 'returns the expected query string' do
@@ -128,7 +128,7 @@ describe WorkOS::SSO do
       it 'returns the expected hostname' do
         authorization_url = described_class.authorization_url(**args)
 
-        expect(URI.parse(authorization_url).host).to eq(WorkOS::API_HOSTNAME)
+        expect(URI.parse(authorization_url).host).to eq(WorkOS.config.api_hostname)
       end
 
       it 'returns the expected query string' do
@@ -163,7 +163,7 @@ describe WorkOS::SSO do
       it 'returns the expected hostname' do
         authorization_url = described_class.authorization_url(**args)
 
-        expect(URI.parse(authorization_url).host).to eq(WorkOS::API_HOSTNAME)
+        expect(URI.parse(authorization_url).host).to eq(WorkOS.config.api_hostname)
       end
 
       it 'returns the expected query string' do
@@ -198,7 +198,7 @@ describe WorkOS::SSO do
       it 'returns the expected hostname' do
         authorization_url = described_class.authorization_url(**args)
 
-        expect(URI.parse(authorization_url).host).to eq(WorkOS::API_HOSTNAME)
+        expect(URI.parse(authorization_url).host).to eq(WorkOS.config.api_hostname)
       end
 
       it 'returns the expected query string' do
@@ -232,7 +232,7 @@ describe WorkOS::SSO do
       it 'returns the expected hostname' do
         authorization_url = described_class.authorization_url(**args)
 
-        expect(URI.parse(authorization_url).host).to eq(WorkOS::API_HOSTNAME)
+        expect(URI.parse(authorization_url).host).to eq(WorkOS.config.api_hostname)
       end
 
       it 'returns the expected query string' do


### PR DESCRIPTION
## Description
Previously, we were grabbing the value of the `WORKOS_API_HOSTNAME` and `WORKOS_API_KEY` env vars at compile time. For folks using something like dotenv, if dotenv wasn't being loaded before WorkOS then the WorkOS gem wouldn't see the env vars later set by dotenv.

Using lazy loading here helps to ensure that we only capture the environment variables when we actually need them.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
