### PR TITLE
Update version to 2.16.0

### DIFF
--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '2.15.0'
+  VERSION = '2.16.0'
 end


### PR DESCRIPTION
## Description
- Use `list_metadata` instead of `listMetadata` in the `Events` API
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
