### PR TITLE
Add send_magic_auth_code method to UserManagement module

### DIFF
--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -65,6 +65,7 @@ module WorkOS
   autoload :DirectoryUser, 'workos/directory_user'
   autoload :Webhook, 'workos/webhook'
   autoload :Webhooks, 'workos/webhooks'
+  autoload :MagicAuthChallenge, 'workos/magic_auth_challenge'
   autoload :MFA, 'workos/mfa'
   autoload :Factor, 'workos/factor'
   autoload :Challenge, 'workos/challenge'

--- a/lib/workos/magic_auth_challenge.rb
+++ b/lib/workos/magic_auth_challenge.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+# typed: true
+
+module WorkOS
+  # The MagicAuthChallenge class provides a lightweight wrapper around a WorkOS
+  # MagicAuthChallenge resource. This class is not meant to be instantiated in
+  # user space, and is instantiated internally but exposed.
+  class MagicAuthChallenge
+    include HashProvider
+    extend T::Sig
+
+    attr_accessor :id
+
+    sig { params(json: String).void }
+    def initialize(json)
+      raw = parse_json(json)
+
+      @id = T.let(raw.id, String)
+    end
+
+    def to_json(*)
+      {
+        id: id,
+      }
+    end
+
+    private
+
+    sig { params(json_string: String).returns(WorkOS::Types::MagicAuthChallengeStruct) }
+    def parse_json(json_string)
+      hash = JSON.parse(json_string, symbolize_names: true)
+
+      WorkOS::Types::MagicAuthChallengeStruct.new(
+        id: hash[:id],
+      )
+    end
+  end
+end

--- a/lib/workos/types.rb
+++ b/lib/workos/types.rb
@@ -12,6 +12,7 @@ module WorkOS
     require_relative 'types/event_struct'
     require_relative 'types/intent_enum'
     require_relative 'types/list_struct'
+    require_relative 'types/magic_auth_challenge_struct'
     require_relative 'types/organization_struct'
     require_relative 'types/passwordless_session_struct'
     require_relative 'types/profile_struct'

--- a/lib/workos/types/magic_auth_challenge_struct.rb
+++ b/lib/workos/types/magic_auth_challenge_struct.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: true
+
+module WorkOS
+  module Types
+    # This MagicAuthChallengeStruct acts as a typed interface for the
+    # MagicAuthChallenge class
+    class MagicAuthChallengeStruct < T::Struct
+      const :id, String
+    end
+  end
+end

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -124,6 +124,30 @@ module WorkOS
         WorkOS::User.new(response.body)
       end
 
+      # Creates a one-time Magic Auth code and emails it to the user.
+      #
+      # @param [String] email_address The email address the one-time code will be sent to.
+      #
+      # @return WorkOS::MagicAuthChallenge
+      sig do
+        params(
+          email_address: String,
+        ).returns(WorkOS::MagicAuthChallenge)
+      end
+      def send_magic_auth_code(email_address:)
+        response = execute_request(
+          request: post_request(
+            path: '/users/magic_auth/send',
+            body: {
+              email_address: email_address,
+            },
+            auth: true,
+          ),
+        )
+
+        WorkOS::MagicAuthChallenge.new(response.body)
+      end
+
       # Sends a verification email to the provided user.
       #
       # @param [String] id The unique ID of the User whose email address will be verified.

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -133,6 +133,20 @@ describe WorkOS::UserManagement do
     end
   end
 
+  describe '.send_magic_auth_code' do
+    context 'with valid parameters' do
+      it 'sends a magic link to the email address' do
+        VCR.use_cassette 'user_management/send_magic_auth_code/valid' do
+          magic_auth_challenge = described_class.send_magic_auth_code(
+            email_address: 'lucy.lawless@example.com',
+          )
+
+          expect(magic_auth_challenge.id).to eq('auth_challenge_01H8D0ZVH77EEYMDJJRRT8A8AC')
+        end
+      end
+    end
+  end
+
   describe '.send_verification_email' do
     context 'with valid paramters' do
       it 'sends an email to that user and returns it' do

--- a/spec/support/fixtures/vcr_cassettes/user_management/send_magic_auth_code/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/send_magic_auth_code/valid.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.workos.com/users/magic_auth/send
+    body:
+      encoding: UTF-8
+      string: '{"email_address":"lucy.lawless@example.com"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/3.0.2; arm64-darwin22; v2.16.0
+      Authorization:
+      - Bearer <API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Aug 2023 21:46:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 7fa6111c5c2b1809-EWR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Etag:
+      - W/"52-oA5fpzR/tRSq0MoPAXFAcFsRNp4"
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin, Accept-Encoding
+      Via:
+      - 1.1 spaces-router (devel)
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      Expect-Ct:
+      - max-age=0
+      Referrer-Policy:
+      - no-referrer
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - a5bf108f-d037-48ba-9435-8ae711d1ed56
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - __cf_bm=kmWmGFJMMgJAEDAve0.eNDzUD9mWFly0koG4br1IdR0-1692654366-0-AYncwjm9sL+G8ry+OiZqo75C/vdFd5zq9hm2N2TMNZDu92JZ8mWlrhFXrmUCaBwT2kh01S4XKGwIKcFw8sdYPEc=;
+        path=/; expires=Mon, 21-Aug-23 22:16:06 GMT; domain=.workos.com; HttpOnly;
+        Secure; SameSite=None
+      - __cfruid=f1dd4a9696fc572e9c12797b2f4b4ad61ac2ad5c-1692654366; path=/; domain=.workos.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"object":"magic_auth_challenge","id":"auth_challenge_01H8D0ZVH77EEYMDJJRRT8A8AC"}'
+    http_version:
+  recorded_at: Mon, 21 Aug 2023 21:46:06 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description

* Creates a one-time Magic Auth code and emails it to the user.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
