### PR TITLE
Bring User in line with current API

### DIFF
--- a/lib/workos/types/user_struct.rb
+++ b/lib/workos/types/user_struct.rb
@@ -9,10 +9,7 @@ module WorkOS
       const :email, String
       const :first_name, T.nilable(String)
       const :last_name, T.nilable(String)
-      const :email_verified_at, T.nilable(String)
-      const :google_oauth_profile_id, T.nilable(String)
-      const :sso_profile_id, T.nilable(String)
-      const :user_type, String
+      const :email_verified, T::Boolean
       const :created_at, String
       const :updated_at, String
     end

--- a/lib/workos/user.rb
+++ b/lib/workos/user.rb
@@ -9,11 +9,9 @@ module WorkOS
     include HashProvider
     extend T::Sig
 
-    attr_accessor :id, :email, :first_name, :last_name, :sso_profile_id,
-                  :email_verified_at, :google_oauth_profile_id, :user_type,
+    attr_accessor :id, :email, :first_name, :last_name, :email_verified,
                   :created_at, :updated_at
 
-    # rubocop:disable Metrics/AbcSize
     sig { params(json: String).void }
     def initialize(json)
       raw = parse_json(json)
@@ -22,14 +20,10 @@ module WorkOS
       @email = T.let(raw.email, String)
       @first_name = raw.first_name
       @last_name = raw.last_name
-      @email_verified_at = raw.email_verified_at
-      @google_oauth_profile_id = raw.google_oauth_profile_id
-      @sso_profile_id = raw.sso_profile_id
-      @user_type = T.let(raw.user_type, String)
+      @email_verified = raw.email_verified
       @created_at = T.let(raw.created_at, String)
       @updated_at = T.let(raw.updated_at, String)
     end
-    # rubocop:enable Metrics/AbcSize
 
     def to_json(*)
       {
@@ -37,10 +31,7 @@ module WorkOS
         email: email,
         first_name: first_name,
         last_name: last_name,
-        email_verified_at: email_verified_at,
-        google_oauth_profile_id: google_oauth_profile_id,
-        sso_profile_id: sso_profile_id,
-        user_type: user_type,
+        email_verified: email_verified,
         created_at: created_at,
         updated_at: updated_at,
       }
@@ -57,10 +48,7 @@ module WorkOS
         email: hash[:email],
         first_name: hash[:first_name],
         last_name: hash[:last_name],
-        email_verified_at: hash[:email_verified_at],
-        google_oauth_profile_id: hash[:google_oauth_profile_id],
-        sso_profile_id: hash[:sso_profile_id],
-        user_type: hash[:user_type],
+        email_verified: hash[:email_verified],
         created_at: hash[:created_at],
         updated_at: hash[:updated_at],
       )

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -143,7 +143,6 @@ module WorkOS
       # Retrieve a list of users.
       #
       # @param [Hash] options
-      # @option options [String] type Filter Users by their type.
       # @option options [String] email Filter Users by their email.
       # @option options [String] organization Filter Users by the organization
       #  they are members of.

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -172,7 +172,7 @@ describe WorkOS::UserManagement do
     context 'with options' do
       it 'returns a list of matching users' do
         request_args = [
-          '/users?email=lucy.lawless%40example.com&type=unmanaged&order=desc&limit=5',
+          '/users?email=lucy.lawless%40example.com&order=desc&limit=5',
           'Content-Type' => 'application/json'
         ]
 
@@ -184,7 +184,6 @@ describe WorkOS::UserManagement do
         VCR.use_cassette 'user_management/list_users/with_options' do
           users = described_class.list_users(
             email: 'lucy.lawless@example.com',
-            type: 'unmanaged',
             order: 'desc',
             limit: '5',
           )

--- a/spec/support/fixtures/vcr_cassettes/user_management/add_user_to_organization_valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/add_user_to_organization_valid.yml
@@ -1,82 +1,82 @@
 ---
 http_interactions:
-- request:
-    method: post
-    uri: https://api.workos.com/users/user_01H7WRJBPAAHX1BYRQHEK7QC4A/organizations
-    body:
-      encoding: UTF-8
-      string: '{"organization_id":"org_01GEQJ8PKE4WH1Q09RSC8CCVJ1"}'
-    headers:
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - WorkOS; ruby/3.0.2; arm64-darwin22; v2.16.0
-      Authorization:
-      - Bearer <API_KEY>
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 17 Aug 2023 14:38:17 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '327'
-      Connection:
-      - keep-alive
-      Cf-Ray:
-      - 7f82a8ed0e9a78e8-EWR
-      Cf-Cache-Status:
-      - DYNAMIC
-      Etag:
-      - W/"147-TjNiyizs89qZMaCxO6Rci3VnXu8"
-      Strict-Transport-Security:
-      - max-age=15552000; includeSubDomains
-      Vary:
-      - Origin, Accept-Encoding
-      Via:
-      - 1.1 spaces-router (devel)
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Content-Security-Policy:
-      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
-        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
-        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
-      Expect-Ct:
-      - max-age=0
-      Referrer-Policy:
-      - no-referrer
-      X-Content-Type-Options:
-      - nosniff
-      X-Dns-Prefetch-Control:
-      - 'off'
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - 2d31ed4e-74e6-44a6-bd1d-bc38dce3b5db
-      X-Xss-Protection:
-      - '0'
-      Set-Cookie:
-      - __cf_bm=RLRUXrYEefq5UfSyC4f.8yqQkG8Mco8Lu_49dF_lFu0-1692283097-0-AYNeWEgwDE/3QNw3rsn5/Kqq8aDtsgx+OkeeN+sMgmbA4ObvCJj4yudUVg1ZDPgkvKdqcxG46ydzK7U92mkOgn0=;
-        path=/; expires=Thu, 17-Aug-23 15:08:17 GMT; domain=.workos.com; HttpOnly;
-        Secure; SameSite=None
-      - __cfruid=258dc88bff2aab7234cf2c93c1c411c653f6f594-1692283097; path=/; domain=.workos.com;
-        HttpOnly; Secure; SameSite=None
-      Server:
-      - cloudflare
-    body:
-      encoding: UTF-8
-      string: '{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-15T14:11:04.519Z","user_type":"unmanaged","email_verified_at":null,"google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}'
-    http_version:
-  recorded_at: Thu, 17 Aug 2023 14:38:17 GMT
+  - request:
+      method: post
+      uri: https://api.workos.com/users/user_01H7WRJBPAAHX1BYRQHEK7QC4A/organizations
+      body:
+        encoding: UTF-8
+        string: '{"organization_id":"org_01GEQJ8PKE4WH1Q09RSC8CCVJ1"}'
+      headers:
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - WorkOS; ruby/3.0.2; arm64-darwin22; v2.16.0
+        Authorization:
+          - Bearer <API_KEY>
+    response:
+      status:
+        code: 201
+        message: Created
+      headers:
+        Date:
+          - Thu, 17 Aug 2023 14:38:17 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "327"
+        Connection:
+          - keep-alive
+        Cf-Ray:
+          - 7f82a8ed0e9a78e8-EWR
+        Cf-Cache-Status:
+          - DYNAMIC
+        Etag:
+          - W/"147-TjNiyizs89qZMaCxO6Rci3VnXu8"
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        Vary:
+          - Origin, Accept-Encoding
+        Via:
+          - 1.1 spaces-router (devel)
+        Access-Control-Allow-Credentials:
+          - "true"
+        Content-Security-Policy:
+          - "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self'
+            https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src
+            'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+        Expect-Ct:
+          - max-age=0
+        Referrer-Policy:
+          - no-referrer
+        X-Content-Type-Options:
+          - nosniff
+        X-Dns-Prefetch-Control:
+          - "off"
+        X-Download-Options:
+          - noopen
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Request-Id:
+          - 2d31ed4e-74e6-44a6-bd1d-bc38dce3b5db
+        X-Xss-Protection:
+          - "0"
+        Set-Cookie:
+          - __cf_bm=RLRUXrYEefq5UfSyC4f.8yqQkG8Mco8Lu_49dF_lFu0-1692283097-0-AYNeWEgwDE/3QNw3rsn5/Kqq8aDtsgx+OkeeN+sMgmbA4ObvCJj4yudUVg1ZDPgkvKdqcxG46ydzK7U92mkOgn0=;
+            path=/; expires=Thu, 17-Aug-23 15:08:17 GMT; domain=.workos.com; HttpOnly;
+            Secure; SameSite=None
+          - __cfruid=258dc88bff2aab7234cf2c93c1c411c653f6f594-1692283097; path=/; domain=.workos.com;
+            HttpOnly; Secure; SameSite=None
+        Server:
+          - cloudflare
+      body:
+        encoding: UTF-8
+        string: '{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-15T14:11:04.519Z","email_verified":true}'
+      http_version:
+    recorded_at: Thu, 17 Aug 2023 14:38:17 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/confirm_password_reset/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/confirm_password_reset/valid.yml
@@ -76,7 +76,7 @@ http_interactions:
       - cloudflare
     body:
       encoding: UTF-8
-      string: '{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-22T20:34:49.277Z","user_type":"unmanaged","email_verified_at":null,"google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}'
+      string: '{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-22T20:34:49.277Z","email_verified":false}'
     http_version:
   recorded_at: Tue, 22 Aug 2023 20:35:40 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/create_password_reset_challenge/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/create_password_reset_challenge/valid.yml
@@ -76,7 +76,7 @@ http_interactions:
       - cloudflare
     body:
       encoding: UTF-8
-      string: '{"token":"rg8vGZMLw94dXmdqAbb42xrwN","user":{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-17T19:43:38.890Z","user_type":"unmanaged","email_verified_at":null,"google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}}'
+      string: '{"token":"rg8vGZMLw94dXmdqAbb42xrwN","user":{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-17T19:43:38.890Z","email_verified":false}}'
     http_version:
   recorded_at: Tue, 22 Aug 2023 15:17:54 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/create_user_valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/create_user_valid.yml
@@ -76,7 +76,7 @@ http_interactions:
       - cloudflare
     body:
       encoding: UTF-8
-      string: '{"object":"user","id":"user_01H81XWBPCV7Y9Q3DHCZHZ9SF8","email":"foo@example.com","first_name":"Foo","last_name":"Bar","created_at":"2023-08-17T14:20:07.199Z","updated_at":"2023-08-17T14:20:07.199Z","user_type":"unmanaged","email_verified_at":"2023-08-17T14:20:07.243Z","google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}'
+      string: '{"object":"user","id":"user_01H81XWBPCV7Y9Q3DHCZHZ9SF8","email":"foo@example.com","first_name":"Foo","last_name":"Bar","created_at":"2023-08-17T14:20:07.199Z","updated_at":"2023-08-17T14:20:07.199Z","email_verified":true}'
     http_version:
   recorded_at: Thu, 17 Aug 2023 14:20:07 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/get_user.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/get_user.yml
@@ -76,7 +76,7 @@ http_interactions:
           - cloudflare
       body:
         encoding: ASCII-8BIT
-        string: '{"object":"user","id":"user_01H7TVSKS45SDHN5V9XPSM6H44","email":"bob@example.com","first_name":"Bob","last_name":"Loblaw","created_at":"2023-08-14T20:28:58.929Z","updated_at":"2023-08-14T20:28:58.929Z","user_type":"unmanaged","email_verified_at":null,"google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}'
+        string: '{"object":"user","id":"user_01H7TVSKS45SDHN5V9XPSM6H44","email":"bob@example.com","first_name":"Bob","last_name":"Loblaw","created_at":"2023-08-14T20:28:58.929Z","updated_at":"2023-08-14T20:28:58.929Z","email_verified":false}'
       http_version:
     recorded_at: Mon, 14 Aug 2023 21:42:04 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/list_users/no_options.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/list_users/no_options.yml
@@ -76,7 +76,7 @@ http_interactions:
           - cloudflare
       body:
         encoding: ASCII-8BIT
-        string: '{"object":"list","data":[{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-15T14:11:04.519Z","user_type":"unmanaged","email_verified_at":null,"google_oauth_profile_id":null,"microsoft_oauth_profile_id":null},{"object":"user","id":"user_01H7TVSKS45SDHN5V9XPSM6H44","email":"bob@loblaw.com","first_name":"Bob","last_name":"Loblaw","created_at":"2023-08-14T20:28:58.929Z","updated_at":"2023-08-14T20:28:58.929Z","user_type":"unmanaged","email_verified_at":null,"google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}],"list_metadata":{"before":"before-id","after":null}}'
+        string: '{"object":"list","data":[{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-15T14:11:04.519Z","email_verified":false},{"object":"user","id":"user_01H7TVSKS45SDHN5V9XPSM6H44","email":"bob@loblaw.com","first_name":"Bob","last_name":"Loblaw","created_at":"2023-08-14T20:28:58.929Z","updated_at":"2023-08-14T20:28:58.929Z","email_verified":false}],"list_metadata":{"before":"before-id","after":null}}'
       http_version:
     recorded_at: Tue, 15 Aug 2023 14:12:43 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/list_users/with_options.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/list_users/with_options.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.workos.com/users?email=lucy.lawless@example.com&limit=5&order=desc&type=unmanaged
+    uri: https://api.workos.com/users?email=lucy.lawless@example.com&limit=5&order=desc
     body:
       encoding: US-ASCII
       string: ''
@@ -76,7 +76,7 @@ http_interactions:
       - cloudflare
     body:
       encoding: ASCII-8BIT
-      string: '{"object":"list","data":[{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-15T14:11:04.519Z","user_type":"unmanaged","email_verified_at":null,"google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}],"list_metadata":{"before":null,"after":null}}'
+      string: '{"object":"list","data":[{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-15T14:11:04.519Z","email_verified":false}],"list_metadata":{"before":null,"after":null}}'
     http_version:
   recorded_at: Tue, 15 Aug 2023 16:37:20 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/remove_user_from_organization_valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/remove_user_from_organization_valid.yml
@@ -76,7 +76,7 @@ http_interactions:
       - cloudflare
     body:
       encoding: ASCII-8BIT
-      string: '{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-15T14:11:04.519Z","user_type":"unmanaged","email_verified_at":null,"google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}'
+      string: '{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-15T14:11:04.519Z","email_verified":true}'
     http_version:
   recorded_at: Thu, 17 Aug 2023 15:38:37 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/verify_email/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/verify_email/valid.yml
@@ -76,7 +76,7 @@ http_interactions:
           - cloudflare
       body:
         encoding: UTF-8
-        string: '{"object":"user","id":"user_01H7TVSKS45SDHN5V9XPSM6H44","email":"bob.loblaw@example.com","first_name":"Bob","last_name":"Loblaw","created_at":"2023-08-14T20:28:58.929Z","updated_at":"2023-08-22T11:18:01.837Z","user_type":"unmanaged","email_verified_at":"2023-08-22T11:18:01.850Z","google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}'
+        string: '{"object":"user","id":"user_01H7TVSKS45SDHN5V9XPSM6H44","email":"bob.loblaw@example.com","first_name":"Bob","last_name":"Loblaw","created_at":"2023-08-14T20:28:58.929Z","updated_at":"2023-08-22T11:18:01.837Z","user_type":"unmanaged","email_verified":true,"google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}'
       http_version:
     recorded_at: Tue, 22 Aug 2023 11:18:01 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description

* Rename email_verified_at to email_verified and change it to a boolean.
* Remove all *_profile_id fields.
* Remove user_type field from User.
* Remove type argument from list_users.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
