### PR TITLE
Add authenticate_user_magic_auth method to UserManagement module

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -355,6 +355,7 @@ module WorkOS
 
         WorkOS::User.new(response.body)
       end
+
       # Authenticates user by email and password.
       #
       # @param [String] email The email address of the user.
@@ -364,6 +365,7 @@ module WorkOS
       # @param [String] client_id The WorkOS client ID for the environment
       #
       # @return WorkOS::AuthenticationResponse
+
       sig do
         params(
           email: String,
@@ -385,6 +387,43 @@ module WorkOS
               ip_address: ip_address,
               user_agent: user_agent,
               grant_type: 'password',
+            },
+          ),
+        )
+        WorkOS::AuthenticationResponse.new(response.body)
+      end
+
+      # Authenticates user by email and password.
+      #
+      # @param [String] code The one-time code that was emailed to the user.
+      # @param [String] user_id The unique ID of the User who will be authenticated.
+      # @param [String] client_id The WorkOS client ID for the environment
+      # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
+      # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
+      #
+      # @return WorkOS::AuthenticationResponse
+
+      sig do
+        params(
+          code: String,
+          user_id: String,
+          client_id: String,
+          ip_address: T.nilable(String),
+          user_agent: T.nilable(String),
+        ).returns(WorkOS::AuthenticationResponse)
+      end
+      def authenticate_user_magic_auth(code:, user_id:, client_id:, ip_address: nil, user_agent: nil)
+        response = execute_request(
+          request: post_request(
+            path: '/users/authenticate',
+            body: {
+              code: code,
+              user_id: user_id,
+              client_id: client_id,
+              client_secret: WorkOS.config.key!,
+              ip_address: ip_address,
+              user_agent: user_agent,
+              grant_type: 'urn:workos:oauth:grant-type:magic-auth:code',
             },
           ),
         )

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -393,7 +393,7 @@ module WorkOS
         WorkOS::AuthenticationResponse.new(response.body)
       end
 
-      # Authenticates user by email and password.
+      # Authenticates user by Magic Auth Code.
       #
       # @param [String] code The one-time code that was emailed to the user.
       # @param [String] user_id The unique ID of the User who will be authenticated.

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -397,7 +397,7 @@ module WorkOS
       #
       # @param [String] code The one-time code that was emailed to the user.
       # @param [String] user_id The unique ID of the User who will be authenticated.
-      # @param [String] client_id The WorkOS client ID for the environment
+      # @param [String] client_id The WorkOS client ID for the environment.
       # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
       #

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -414,5 +414,39 @@ describe WorkOS::UserManagement do
         end
       end
     end
+
+    describe '.authenticate_user_magic_auth' do
+      context 'with a valid password' do
+        it 'returns user' do
+          VCR.use_cassette('user_management/authenticate_user_magic_auth/valid') do
+            authentication_response = WorkOS::UserManagement.authenticate_user_magic_auth(
+              code: '452079',
+              user_id: 'user_01H93WD0R0KWF8Q7BK02C0RPYJ',
+              client_id: 'client_123',
+              ip_address: '200.240.210.16',
+              user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36',
+            )
+            puts authentication_response
+            expect(authentication_response.user.id).to eq('user_01H93WD0R0KWF8Q7BK02C0RPYJ')
+          end
+        end
+      end
+
+      context 'with an incorrect user id' do
+        it 'raises an error' do
+          VCR.use_cassette('user_management/authenticate_user_magic_auth/invalid') do
+            expect do
+              WorkOS::UserManagement.authenticate_user_magic_auth(
+                code: '452079',
+                user_id: 'user_01H93WD0R0KWF8Q7BK02C0RPY',
+                client_id: 'client_123',
+                ip_address: '200.240.210.16',
+                user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36',
+              )
+            end.to raise_error(WorkOS::APIError, /User not found/)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/support/fixtures/vcr_cassettes/user_management/authenticate_user_magic_auth/invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/authenticate_user_magic_auth/invalid.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.workos.com/users/authenticate
+      body:
+        encoding: UTF-8
+        string:
+          '{"code":"test@workos.app","user_id":"user_01H93WD0R0KWF8Q7BK02C0RPY","client_id":"client_123","client_secret":"<API_KEY>","ip_address":"200.240.210.16","user_agent":"Mozilla/5.0
+          (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36","grant_type":"urn:workos:oauth:grant-type:magic-auth:code"}'
+      headers:
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - WorkOS; ruby/3.0.2; arm64-darwin21; v2.16.0
+    response:
+      status:
+        code: 404
+        message: Not Found
+      headers:
+        Date:
+          - Wed, 30 Aug 2023 18:58:01 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Cf-Ray:
+          - 7fef4344cb386811-SEA
+        Cf-Cache-Status:
+          - DYNAMIC
+        Etag:
+          - W/"86-X4Q7F02iXed9FifFtOSpB/M42Bc"
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        Vary:
+          - Origin, Accept-Encoding
+        Via:
+          - 1.1 spaces-router (devel)
+        Access-Control-Allow-Credentials:
+          - "true"
+        Content-Security-Policy:
+          - "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self'
+            https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src
+            'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+        Expect-Ct:
+          - max-age=0
+        Referrer-Policy:
+          - no-referrer
+        X-Content-Type-Options:
+          - nosniff
+        X-Dns-Prefetch-Control:
+          - "off"
+        X-Download-Options:
+          - noopen
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Request-Id:
+          - 4d33111f-a488-4250-a946-7dceb07af151
+        X-Xss-Protection:
+          - "0"
+        Set-Cookie:
+          - __cf_bm=vPqfj2Z.hrS6vFkS6IuPzCyzTvKEzqKRxfwaaFAaaO8-1693421881-0-AUTukg7nPdQwavyZXIMKFWXnk+xXmC4q0ioe3Jalz3feLjTbouHB5lBI/Qp99KfZyslQxRxMlvJPeDo2iBOYbGs=;
+            path=/; expires=Wed, 30-Aug-23 19:28:01 GMT; domain=.workos.com; HttpOnly;
+            Secure; SameSite=None
+          - __cfruid=16391e6119f12d4d9bca79552f799341cb54e8ef-1693421881; path=/; domain=.workos.com;
+            HttpOnly; Secure; SameSite=None
+        Server:
+          - cloudflare
+      body:
+        encoding: ASCII-8BIT
+        string: '{"message":"User not found: ''user_01H93WD0R0KWF8Q7BK02C0RPY''.","code":"entity_not_found","entity_id":"user_01H93WD0R0KWF8Q7BK02C0RPY"}'
+      http_version:
+    recorded_at: Wed, 30 Aug 2023 18:58:01 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/authenticate_user_magic_auth/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/authenticate_user_magic_auth/valid.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.workos.com/users/authenticate
+      body:
+        encoding: UTF-8
+        string:
+          '{"code":"452079","user_id":"user_01H93WD0R0KWF8Q7BK02C0RPYJ","client_id":"client_123","client_secret":"<API_KEY>","ip_address":"200.240.210.16","user_agent":"Mozilla/5.0
+          (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36","grant_type":"urn:workos:oauth:grant-type:magic-auth:code"}'
+      headers:
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - WorkOS; ruby/3.0.2; arm64-darwin21; v2.16.0
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Wed, 30 Aug 2023 18:58:00 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Cf-Ray:
+          - 7fef43410e21ec40-SEA
+        Cf-Cache-Status:
+          - DYNAMIC
+        Etag:
+          - W/"178-SVaSEtrIczZQlwnTK57+aDrxt/g"
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        Vary:
+          - Origin, Accept-Encoding
+        Via:
+          - 1.1 spaces-router (devel)
+        Access-Control-Allow-Credentials:
+          - "true"
+        Content-Security-Policy:
+          - "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self'
+            https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src
+            'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+        Expect-Ct:
+          - max-age=0
+        Referrer-Policy:
+          - no-referrer
+        X-Content-Type-Options:
+          - nosniff
+        X-Dns-Prefetch-Control:
+          - "off"
+        X-Download-Options:
+          - noopen
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Request-Id:
+          - ba8fd1ed-34e6-408e-afe0-75e16e6cf3cb
+        X-Xss-Protection:
+          - "0"
+        Set-Cookie:
+          - __cf_bm=ltLsz5yJcK6FuzoGfz2T0FBF9H_Lii_9fMu.1kAgrw8-1693421880-0-AR414sJ/FdSxY+N35vtic7XqJ78+FE0W2D5l5tR5eJbVJcm2X5/eqNg9xzMprMd1J1Eegol3Qa1KMntgknAj9l8=;
+            path=/; expires=Wed, 30-Aug-23 19:28:00 GMT; domain=.workos.com; HttpOnly;
+            Secure; SameSite=None
+          - __cfruid=d0c3b10fd259e1dd63341e19d261a235baabb4af-1693421880; path=/; domain=.workos.com;
+            HttpOnly; Secure; SameSite=None
+        Server:
+          - cloudflare
+      body:
+        encoding: ASCII-8BIT
+        string: '{"user":{"object":"user","id":"user_01H93WD0R0KWF8Q7BK02C0RPYJ","email":"test@workos.app","email_verified":true,"first_name":"Lucille","last_name":"Bluth","created_at":"2023-08-30T18:48:26.517Z","updated_at":"2023-08-30T18:58:00.821Z","user_type":"unmanaged","email_verified_at":"2023-08-30T18:58:00.915Z","google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}}'
+      http_version:
+    recorded_at: Wed, 30 Aug 2023 18:58:00 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description
Adds authenticate_user_magic_auth, tests, and fixtures.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
