### PR TITLE
Add authenticate_user_with_code method to UserManagement module

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -390,6 +390,40 @@ module WorkOS
         )
         WorkOS::AuthenticationResponse.new(response.body)
       end
+
+      # Authenticates a user using OAuth code.
+      #
+      # @param [String] code The one-time code that was emailed to the user.
+      # @param [String] client_id The WorkOS client ID for the environment
+      # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
+      # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
+      #
+      # @return WorkOS::AuthenticationResponse
+
+      sig do
+        params(
+          code: String,
+          client_id: String,
+          ip_address: T.nilable(String),
+          user_agent: T.nilable(String),
+        ).returns(WorkOS::AuthenticationResponse)
+      end
+      def authenticate_user_with_code(code:, client_id:, ip_address: nil, user_agent: nil)
+        response = execute_request(
+          request: post_request(
+            path: '/users/authenticate',
+            body: {
+              code: code,
+              client_id: client_id,
+              client_secret: WorkOS.config.key!,
+              ip_address: ip_address,
+              user_agent: user_agent,
+              grant_type: 'authorization_code',
+            },
+          ),
+        )
+        WorkOS::AuthenticationResponse.new(response.body)
+      end
     end
   end
   # rubocop:enable Metrics/ModuleLength

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -429,7 +429,7 @@ module WorkOS
         )
         WorkOS::AuthenticationResponse.new(response.body)
       end
-      
+
       # Authenticates a user using OAuth code.
       #
       # @param [String] code The one-time code that was emailed to the user.

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -415,4 +415,36 @@ describe WorkOS::UserManagement do
       end
     end
   end
+
+  describe '.authenticate_user_with_code' do
+    context 'with a valid password' do
+      it 'returns user' do
+        VCR.use_cassette('user_management/authenticate_user_with_code/valid') do
+          authentication_response = WorkOS::UserManagement.authenticate_user_with_code(
+            code: '01H93ZZHA0JBHFJH9RR11S83YN',
+            client_id: 'client_123',
+            ip_address: '200.240.210.16',
+            user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36',
+          )
+          puts authentication_response
+          expect(authentication_response.user.id).to eq('user_01H93ZY4F80YZRRS6N59Z2HFVS')
+        end
+      end
+    end
+
+    context 'with an incorrect user id' do
+      it 'raises an error' do
+        VCR.use_cassette('user_management/authenticate_user_with_code/invalid') do
+          expect do
+            WorkOS::UserManagement.authenticate_user_with_code(
+              code: '452079',
+              client_id: 'client_123',
+              ip_address: '200.240.210.16',
+              user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36',
+            )
+          end.to raise_error(WorkOS::InvalidRequestError, /Status 400/)
+        end
+      end
+    end
+  end
 end

--- a/spec/support/fixtures/vcr_cassettes/user_management/authenticate_user_with_code/invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/authenticate_user_with_code/invalid.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.workos.com/users/authenticate
+      body:
+        encoding: UTF-8
+        string:
+          '{"code":"452079","client_id":"client_123","client_secret":"<API_KEY>","ip_address":"200.240.210.16","user_agent":"Mozilla/5.0
+          (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36","grant_type":"authorization_code"}'
+      headers:
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - WorkOS; ruby/3.0.2; arm64-darwin21; v2.16.0
+    response:
+      status:
+        code: 400
+        message: Bad Request
+      headers:
+        Date:
+          - Wed, 30 Aug 2023 19:51:51 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - "92"
+        Connection:
+          - keep-alive
+        Cf-Ray:
+          - 7fef92211809c715-SEA
+        Cf-Cache-Status:
+          - DYNAMIC
+        Etag:
+          - W/"5c-iYZxvYBkO+QosPHgQENUzbE8Uac"
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        Vary:
+          - Origin, Accept-Encoding
+        Via:
+          - 1.1 spaces-router (devel)
+        Access-Control-Allow-Credentials:
+          - "true"
+        Content-Security-Policy:
+          - "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self'
+            https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src
+            'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+        Expect-Ct:
+          - max-age=0
+        Referrer-Policy:
+          - no-referrer
+        X-Content-Type-Options:
+          - nosniff
+        X-Dns-Prefetch-Control:
+          - "off"
+        X-Download-Options:
+          - noopen
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Request-Id:
+          - 470506e4-7be1-464c-8d2c-8ce98207bff6
+        X-Xss-Protection:
+          - "0"
+        Set-Cookie:
+          - __cf_bm=T4FglgOdveH_UrrH3p1bZTMlmgx6dOp6MwUIacX.Ilw-1693425111-0-AeeLZFZ2Ai2iZTCSKu01aHk1f9fy95FYgYE79bYIpSi63zy8YTFMKhaIQlHj2CfrK485zE0frTrbD+76Rve+trw=;
+            path=/; expires=Wed, 30-Aug-23 20:21:51 GMT; domain=.workos.com; HttpOnly;
+            Secure; SameSite=None
+          - __cfruid=3e9a5d359ba92753e7626245fef8b2f1ee096477-1693425111; path=/; domain=.workos.com;
+            HttpOnly; Secure; SameSite=None
+        Server:
+          - cloudflare
+      body:
+        encoding: UTF-8
+        string:
+          '{"error":"invalid_grant","error_description":"The code ''452079'' has
+          expired or is invalid."}'
+      http_version:
+    recorded_at: Wed, 30 Aug 2023 19:51:51 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/authenticate_user_with_code/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/authenticate_user_with_code/valid.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.workos.com/users/authenticate
+      body:
+        encoding: UTF-8
+        string:
+          '{"code":"01H93ZZHA0JBHFJH9RR11S83YN","client_id":"client_123","client_secret":"<API_KEY>","ip_address":"200.240.210.16","user_agent":"Mozilla/5.0
+          (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36","grant_type":"authorization_code"}'
+      headers:
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - WorkOS; ruby/3.0.2; arm64-darwin21; v2.16.0
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Wed, 30 Aug 2023 19:51:51 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Cf-Ray:
+          - 7fef921deeca091f-SEA
+        Cf-Cache-Status:
+          - DYNAMIC
+        Etag:
+          - W/"13b-pHataL1lHEvsW5EO4vq5QgAdcWw"
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        Vary:
+          - Origin, Accept-Encoding
+        Via:
+          - 1.1 spaces-router (devel)
+        Access-Control-Allow-Credentials:
+          - "true"
+        Content-Security-Policy:
+          - "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self'
+            https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src
+            'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+        Expect-Ct:
+          - max-age=0
+        Referrer-Policy:
+          - no-referrer
+        X-Content-Type-Options:
+          - nosniff
+        X-Dns-Prefetch-Control:
+          - "off"
+        X-Download-Options:
+          - noopen
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Request-Id:
+          - 630bec5a-5a13-4311-a0b7-958889a3bbb2
+        X-Xss-Protection:
+          - "0"
+        Set-Cookie:
+          - __cf_bm=o5KBdIAUFZp0azSQnnd1GlQcIlcPCz95uFg6hFNnKM8-1693425111-0-ARSauqdojZdKD6Z7vp12JBrxCp6wE1s0JzEhaN0XE2DqME76OnJiDJugj2TsbNGXtqWaH3By7XHUXVZDf+AdFxU=;
+            path=/; expires=Wed, 30-Aug-23 20:21:51 GMT; domain=.workos.com; HttpOnly;
+            Secure; SameSite=None
+          - __cfruid=3e9a5d359ba92753e7626245fef8b2f1ee096477-1693425111; path=/; domain=.workos.com;
+            HttpOnly; Secure; SameSite=None
+        Server:
+          - cloudflare
+      body:
+        encoding: ASCII-8BIT
+        string: '{"user":{"object":"user","id":"user_01H93ZY4F80YZRRS6N59Z2HFVS","email":"test@workos.app","email_verified":false,"first_name":"Lucille","last_name":"Bluth","created_at":"2023-08-30T19:50:13.214Z","updated_at":"2023-08-30T19:50:13.214Z","user_type":"managed","sso_profile_id":"prof_01H93ZTVWYPAT4RKDSPFPPXH0J"}}'
+      http_version:
+    recorded_at: Wed, 30 Aug 2023 19:51:51 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description
Adds authenticate_user_with_code, tests, and fixtures.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
