### PR TITLE
Change authenticate_user_password client_id param to non-nilable and remove logging statements

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -368,12 +368,12 @@ module WorkOS
         params(
           email: String,
           password: String,
+          client_id: String,
           ip_address: T.nilable(String),
           user_agent: T.nilable(String),
-          client_id: T.nilable(String),
         ).returns(WorkOS::AuthenticationResponse)
       end
-      def authenticate_user_password(email:, password:, ip_address: nil, user_agent: nil, client_id: nil)
+      def authenticate_user_password(email:, password:, client_id:, ip_address: nil, user_agent: nil)
         response = execute_request(
           request: post_request(
             path: '/users/authenticate',

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -315,7 +315,6 @@ describe WorkOS::UserManagement do
             last_name: 'Doe',
             email_verified: false,
           )
-          puts
           expect(user.first_name).to eq('Jane')
           expect(user.last_name).to eq('Doe')
           expect(user.email_verified).to eq(false)
@@ -393,7 +392,6 @@ describe WorkOS::UserManagement do
             ip_address: '200.240.210.16',
             user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36',
           )
-          puts authentication_response
           expect(authentication_response.user.id).to eq('user_01H7TVSKS45SDHN5V9XPSM6H44')
         end
       end


### PR DESCRIPTION
## Description
Changes authenticate_user_password client_id param to non-nilable and remove logging statements

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
