### PR TITLE
Add endpoints for creating and listing auth factors

### DIFF
--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -47,6 +47,7 @@ module WorkOS
   autoload :Client, 'workos/client'
   autoload :Configuration, 'workos/configuration'
   autoload :AuditLogExport, 'workos/audit_log_export'
+  autoload :AuthenticationFactorAndChallenge, 'workos/authentication_factor_and_challenge'
   autoload :AuditLogs, 'workos/audit_logs'
   autoload :AuditTrail, 'workos/audit_trail'
   autoload :Connection, 'workos/connection'

--- a/lib/workos/authentication_factor_and_challenge.rb
+++ b/lib/workos/authentication_factor_and_challenge.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# typed: true
+
+module WorkOS
+  # The AuthenticationFactorAndChallenge class represents
+  # an authentication factor and challenge for a given user.
+  class AuthenticationFactorAndChallenge
+    include HashProvider
+    extend T::Sig
+
+    attr_accessor :authentication_factor, :authentication_challenge
+
+    sig { params(authentication_response_json: String).void }
+    def initialize(authentication_response_json)
+      json = JSON.parse(authentication_response_json, symbolize_names: true)
+      @authentication_factor = WorkOS::Factor.new(
+        json[:authentication_factor].to_json,
+      )
+      @authentication_challenge = WorkOS::Challenge.new(
+        json[:authentication_challenge].to_json,
+      )
+    end
+
+    def to_json(*)
+      {
+        authentication_factor: authentication_factor.to_json,
+        authentication_challenge: authentication_challenge.to_json,
+      }
+    end
+  end
+end

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -465,20 +465,20 @@ module WorkOS
 
       # Enroll a user into an authentication factor.
       #
-      # @param [String] id The id for the user.
+      # @param [String] user_id The id for the user.
       #
       # @return WorkOS::AuthenticationFactorAndChallenge
       sig do
         params(
-          id: String,
+          user_id: String,
         ).returns(WorkOS::AuthenticationFactorAndChallenge)
       end
-      def enroll_auth_factor(id:)
+      def enroll_auth_factor(user_id:)
         response = execute_request(
           request: post_request(
-            path: "/users/#{id}/auth/factors",
+            path: "/users/#{user_id}/auth/factors",
             body: {
-              type: 'topd',
+              type: 'totp',
             },
             auth: true,
           ),
@@ -489,31 +489,31 @@ module WorkOS
 
       # Get all auth factors for a user
       #
-      # @param [String] id The id for the user.
+      # @param [String] user_id The id for the user.
       #
       # @return WorkOS::ListStruct
       sig do
         params(
-          id: String,
+          user_id: String,
         ).returns(WorkOS::Types::ListStruct)
       end
-      def list_auth_factors(id:)
+      def list_auth_factors(user_id:)
         response = execute_request(
           request: get_request(
-            path: "/users/#{id}/auth/factors",
+            path: "/users/#{user_id}/auth/factors",
             auth: true,
           ),
         )
 
         parsed_response = JSON.parse(response.body)
 
-        auth_factors = parsed_response.map do |auth_factor|
+        auth_factors = parsed_response['data'].map do |auth_factor|
           ::WorkOS::Factor.new(auth_factor.to_json)
         end
 
         WorkOS::Types::ListStruct.new(
           data: auth_factors,
-          list_metadata: {},
+          list_metadata: parsed_response['list_metadata'],
         )
       end
     end

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -462,6 +462,60 @@ module WorkOS
         )
         WorkOS::UserResponse.new(response.body)
       end
+
+      # Enroll a user into an authentication factor.
+      #
+      # @param [String] id The id for the user.
+      #
+      # @return WorkOS::AuthenticationFactorAndChallenge
+      sig do
+        params(
+          id: String,
+        ).returns(WorkOS::AuthenticationFactorAndChallenge)
+      end
+      def enroll_auth_factor(id:)
+        response = execute_request(
+          request: post_request(
+            path: "/users/#{id}/auth/factors",
+            body: {
+              type: 'topd',
+            },
+            auth: true,
+          ),
+        )
+
+        WorkOS::AuthenticationFactorAndChallenge.new(response.body)
+      end
+
+      # Get all auth factors for a user
+      #
+      # @param [String] id The id for the user.
+      #
+      # @return WorkOS::Factor
+      sig do
+        params(
+          id: String,
+        ).returns(WorkOS::Types::ListStruct)
+      end
+      def list_auth_factors(id:)
+        response = execute_request(
+          request: get_request(
+            path: "/users/#{id}/auth/factors",
+            auth: true,
+          ),
+        )
+
+        parsed_response = JSON.parse(response.body)
+
+        auth_factors = parsed_response.map do |auth_factor|
+          ::WorkOS::Factor.new(auth_factor.to_json)
+        end
+
+        WorkOS::Types::ListStruct.new(
+          data: auth_factors,
+          list_metadata: {},
+        )
+      end
     end
   end
   # rubocop:enable Metrics/ModuleLength

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -491,7 +491,7 @@ module WorkOS
       #
       # @param [String] id The id for the user.
       #
-      # @return WorkOS::Factor
+      # @return WorkOS::ListStruct
       sig do
         params(
           id: String,

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -476,4 +476,56 @@ describe WorkOS::UserManagement do
       end
     end
   end
+
+  describe '.enroll_auth_factor' do
+    context 'with a valid user_id' do
+      it 'returns an auth factor and challenge' do
+        VCR.use_cassette('user_management/enroll_auth_factor/valid') do
+          authentication_response = WorkOS::UserManagement.enroll_auth_factor(
+            id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
+          )
+
+          expect(authentication_response.authentication_factor.id).to eq('auth_factor_01H96FETXENNY99ARX0GRC804C')
+          expect(authentication_response.authentication_challenge.id).to eq('auth_challenge_01H96FETXGTW1QMBSBT2T36PW0')
+        end
+      end
+    end
+
+    context 'with an incorrect user id' do
+      it 'raises an error' do
+        VCR.use_cassette('user_management/enroll_auth_factor/invalid') do
+          expect do
+            WorkOS::UserManagement.enroll_auth_factor(
+              id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
+            )
+          end.to raise_error(WorkOS::InvalidRequestError, /Status 400/)
+        end
+      end
+    end
+  end
+
+  describe '.list_auth_factors' do
+    context 'with a valid user_id' do
+      it 'returns a list of auth factors' do
+        VCR.use_cassette('user_management/list_auth_factors/valid') do
+          authentication_response = WorkOS::UserManagement.list_auth_factors(
+            id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
+          )
+
+          expect(authentication_response.data.first.id).to eq('auth_factor_01H96FETXENNY99ARX0GRC804C')
+        end
+      end
+    end
+    context 'with an incorrect user id' do
+      it 'raises an error' do
+        VCR.use_cassette('user_management/list_auth_factors/invalid') do
+          expect do
+            WorkOS::UserManagement.list_auth_factors(
+              id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
+            )
+          end.to raise_error(WorkOS::InvalidRequestError, /Status 400/)
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -482,7 +482,7 @@ describe WorkOS::UserManagement do
       it 'returns an auth factor and challenge' do
         VCR.use_cassette('user_management/enroll_auth_factor/valid') do
           authentication_response = WorkOS::UserManagement.enroll_auth_factor(
-            id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
+            user_id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
           )
 
           expect(authentication_response.authentication_factor.id).to eq('auth_factor_01H96FETXENNY99ARX0GRC804C')
@@ -496,7 +496,7 @@ describe WorkOS::UserManagement do
         VCR.use_cassette('user_management/enroll_auth_factor/invalid') do
           expect do
             WorkOS::UserManagement.enroll_auth_factor(
-              id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
+              user_id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
             )
           end.to raise_error(WorkOS::InvalidRequestError, /Status 400/)
         end
@@ -509,7 +509,7 @@ describe WorkOS::UserManagement do
       it 'returns a list of auth factors' do
         VCR.use_cassette('user_management/list_auth_factors/valid') do
           authentication_response = WorkOS::UserManagement.list_auth_factors(
-            id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
+            user_id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
           )
 
           expect(authentication_response.data.first.id).to eq('auth_factor_01H96FETXENNY99ARX0GRC804C')
@@ -521,7 +521,7 @@ describe WorkOS::UserManagement do
         VCR.use_cassette('user_management/list_auth_factors/invalid') do
           expect do
             WorkOS::UserManagement.list_auth_factors(
-              id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
+              user_id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
             )
           end.to raise_error(WorkOS::InvalidRequestError, /Status 400/)
         end

--- a/spec/support/fixtures/vcr_cassettes/user_management/enroll_auth_factor/invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/enroll_auth_factor/invalid.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: post 
+    uri: https://api.workos.com/users/user_01H7TVSKS45SDHN5V9XPSM6H44/auth/factors
+    body:
+      encoding: US-ASCII
+      string: '{"type":"topd"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/3.0.2; arm64-darwin22; v2.16.0
+      Authorization:
+      - 'Bearer '
+  response:
+    status:
+      code: 400
+      message: Bad Request 
+    headers:
+      Date:
+      - Thu, 31 Aug 2023 23:40:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '26'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 7ff91efd88d838e1-YYZ
+      Cf-Cache-Status:
+      - DYNAMIC
+      Etag:
+      - W/"1a-pljHtlo127JYJR4E/RYOPb6ucbw"
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin, Accept-Encoding
+      Via:
+      - 1.1 spaces-router (devel)
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      Expect-Ct:
+      - max-age=0
+      Referrer-Policy:
+      - no-referrer
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 8eae4ac4-8213-4f3f-966f-a2421a113bf8
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - __cf_bm=M_MJukGgDu7U9.wmReWdBW.NzCb1vSBzW1fvbnNPkMo-1693525252-0-AUtIKPsJjb1vSM1Q+ny4TPcpo5BpudZWt0gRLw9x5pZpvSPmYrftp68dc2cjpbRaKieTinfRpgEccLO5HiThNbQ=;
+        path=/; expires=Fri, 01-Sep-23 00:10:52 GMT; domain=.workos.com; HttpOnly;
+        Secure; SameSite=None
+      - __cfruid=8d5f43bf29ca9bafc65d9794d1c54d31c49ef1bf-1693525252; path=/; domain=.workos.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+    body:
+      encoding: UTF-8
+      string: '{"message":"Unauthorized"}'
+    http_version:
+  recorded_at: Thu, 31 Aug 2023 23:40:52 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/enroll_auth_factor/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/enroll_auth_factor/valid.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.workos.com/users/user_01H7TVSKS45SDHN5V9XPSM6H44/auth/factors
     body:
       encoding: UTF-8
-      string: '{"type":"topd"}'
+      string: '{"type":"totp"}'
     headers:
       Content-Type:
       - application/json

--- a/spec/support/fixtures/vcr_cassettes/user_management/enroll_auth_factor/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/enroll_auth_factor/valid.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: post 
+    uri: https://api.workos.com/users/user_01H7TVSKS45SDHN5V9XPSM6H44/auth/factors
+    body:
+      encoding: UTF-8
+      string: '{"type":"topd"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/3.0.2; arm64-darwin21; v2.16.0
+      Authorization:
+      - Bearer <API_KEY>
+  response:
+    status:
+      code: 201
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 Aug 2023 23:37:04 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 7fc7a9287d0330ba-SEA
+      Cf-Cache-Status:
+      - DYNAMIC
+      Etag:
+      - W/"153-w5d8Z7u7b9Obt9NziECtNSAY9Ac"
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin, Accept-Encoding
+      Via:
+      - 1.1 spaces-router (devel)
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      Expect-Ct:
+      - max-age=0
+      Referrer-Policy:
+      - no-referrer
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - b333b9e1-c9ec-4e99-ae4f-17a854859cf1
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - __cf_bm=adC6w3NUNGTpdZDzNn39guANJ9wi798uCuqc_EI8190-1693006624-0-AcpsuyzFE/KdM7ev5pSVTt2vnGqCSZBOuQYZ0iKFiJT0mBlAuNITn3hICEKvcZ4LH7JUIyjnEOWfq2w7JyRmrJ4=;
+        path=/; expires=Sat, 26-Aug-23 00:07:04 GMT; domain=.workos.com; HttpOnly;
+        Secure; SameSite=None
+      - __cfruid=1d0cc3edf886cc7b90bd0c9c3226f5611a385c1a-1693006624; path=/; domain=.workos.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{ "authentication_factor": { "object": "authentication_factor", "id": "auth_factor_01H96FETXENNY99ARX0GRC804C", "user_id": "user_01H96FETWYSJMJEGF0Q3ZB272F", "type": "totp", "totp": { "issuer": "Foo Corp", "qr_code": "data:image/png;base64,iVBOR...", "secret": "OFAFOQAPHR6XMQKAIYMWU72XIE3DGI3P", "uri": "otpauth://totp/Foo%20Corp:user@foo-corp.com?secret=OFAFOQAPHR6XMQKAIYMWU72XIE3DGI3P&issuer=Foo%20Corp&algorithm=SHA1&digits=6&period=30", "user": "user@foo-corp.com" }, "created_at": "2023-08-31T18:59:57.962Z", "updated_at": "2023-08-31T18:59:57.962Z" }, "authentication_challenge": { "object": "authentication_challenge", "id": "auth_challenge_01H96FETXGTW1QMBSBT2T36PW0", "authentication_factor_id": "auth_factor_01H96FETXENNY99ARX0GRC804C", "expires_at": "2023-08-31T19:09:57.999Z", "created_at": "2023-08-31T18:59:57.962Z", "updated_at": "2023-08-31T18:59:57.962Z" } }'
+    http_version:
+  recorded_at: Fri, 25 Aug 2023 23:37:04 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/list_auth_factors/invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/list_auth_factors/invalid.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.workos.com/users/user_01H7TVSKS45SDHN5V9XPSM6H44/auth/factors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/3.0.2; arm64-darwin22; v2.16.0
+      Authorization:
+      - 'Bearer '
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 31 Aug 2023 23:40:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '26'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 7ff91efd88d838e1-YYZ
+      Cf-Cache-Status:
+      - DYNAMIC
+      Etag:
+      - W/"1a-pljHtlo127JYJR4E/RYOPb6ucbw"
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin, Accept-Encoding
+      Via:
+      - 1.1 spaces-router (devel)
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      Expect-Ct:
+      - max-age=0
+      Referrer-Policy:
+      - no-referrer
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 8eae4ac4-8213-4f3f-966f-a2421a113bf8
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - __cf_bm=M_MJukGgDu7U9.wmReWdBW.NzCb1vSBzW1fvbnNPkMo-1693525252-0-AUtIKPsJjb1vSM1Q+ny4TPcpo5BpudZWt0gRLw9x5pZpvSPmYrftp68dc2cjpbRaKieTinfRpgEccLO5HiThNbQ=;
+        path=/; expires=Fri, 01-Sep-23 00:10:52 GMT; domain=.workos.com; HttpOnly;
+        Secure; SameSite=None
+      - __cfruid=8d5f43bf29ca9bafc65d9794d1c54d31c49ef1bf-1693525252; path=/; domain=.workos.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+    body:
+      encoding: UTF-8
+      string: '{"message":"Unauthorized"}'
+    http_version:
+  recorded_at: Thu, 31 Aug 2023 23:40:52 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/list_auth_factors/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/list_auth_factors/valid.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.workos.com/users/user_01H7TVSKS45SDHN5V9XPSM6H44/auth/factors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/3.0.2; arm64-darwin22; v2.16.0
+      Authorization:
+      - Bearer <API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 15 Aug 2023 16:37:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 7f72dc925ef34288-EWR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Etag:
+      - W/"18f-HNgxIMGB3lWwWoxKErsd68S0puU"
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin, Accept-Encoding
+      Via:
+      - 1.1 spaces-router (devel)
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      Expect-Ct:
+      - max-age=0
+      Referrer-Policy:
+      - no-referrer
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 18685295-6afd-47bd-9cc2-e16850f607de
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - __cf_bm=hzs97IV1P8X7vKS74iCCMRDY7sFzoYGcysP2LGdKV4c-1692117440-0-AVjOj8T6njnoEKqAZOnpqnTNC2ufENAOsWFxOZ9qjDN/s/IkKgauQmDgEimgKTQ9w6YFRg7dX1fOt25dRgyLJ/U=;
+        path=/; expires=Tue, 15-Aug-23 17:07:20 GMT; domain=.workos.com; HttpOnly;
+        Secure; SameSite=None
+      - __cfruid=c652b2f4b8b1daf1d2315e44c356d62a89c8d451-1692117440; path=/; domain=.workos.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '[{ "object": "authentication_factor", "id": "auth_factor_01H96FETXENNY99ARX0GRC804C", "user_id": "user_01H96FETWYSJMJEGF0Q3ZB272F", "type": "totp", "totp": { "issuer": "Foo Corp", "user": "user@foo-corp.com" }, "created_at": "2023-08-31T18:59:57.962Z", "updated_at": "2023-08-31T18:59:57.962Z" }]'
+    http_version:
+  recorded_at: Tue, 15 Aug 2023 16:37:20 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/list_auth_factors/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/list_auth_factors/valid.yml
@@ -76,7 +76,7 @@ http_interactions:
       - cloudflare
     body:
       encoding: ASCII-8BIT
-      string: '[{ "object": "authentication_factor", "id": "auth_factor_01H96FETXENNY99ARX0GRC804C", "user_id": "user_01H96FETWYSJMJEGF0Q3ZB272F", "type": "totp", "totp": { "issuer": "Foo Corp", "user": "user@foo-corp.com" }, "created_at": "2023-08-31T18:59:57.962Z", "updated_at": "2023-08-31T18:59:57.962Z" }]'
+      string: '{"object": "list", "data":[{ "object": "authentication_factor", "id": "auth_factor_01H96FETXENNY99ARX0GRC804C", "user_id": "user_01H96FETWYSJMJEGF0Q3ZB272F", "type": "totp", "totp": { "issuer": "Foo Corp", "user": "user@foo-corp.com" }, "created_at": "2023-08-31T18:59:57.962Z", "updated_at": "2023-08-31T18:59:57.962Z" }], "list_metadata": {"before":null, "after":null}}'
     http_version:
   recorded_at: Tue, 15 Aug 2023 16:37:20 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description
Add endpoints for 

1) `enroll_auth_factor` to enroll a user in an auth factor
Introduces a joint object `AuthenticationFactorAndChallenge` for the response 

2) `list_auth_factors` to list a user's auth factors. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ X ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
