### PR TITLE
Rename password specific endpoints

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -74,7 +74,7 @@ module WorkOS
           new_password: String,
         ).returns(WorkOS::User)
       end
-      def confirm_password_reset(token:, new_password:)
+      def reset_password(token:, new_password:)
         response = execute_request(
           request: post_request(
             path: '/users/password_reset',
@@ -101,9 +101,9 @@ module WorkOS
           password_reset_url: String,
         ).returns(WorkOS::UserAndToken)
       end
-      def create_password_reset_challenge(email:, password_reset_url:)
+      def send_password_reset_email(email:, password_reset_url:)
         request = post_request(
-          path: '/users/password_reset_challenge',
+          path: '/users/send_password_reset_email',
           body: {
             email: email,
             password_reset_url: password_reset_url,

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -32,11 +32,11 @@ describe WorkOS::UserManagement do
     end
   end
 
-  describe '.confirm_password_reset' do
+  describe '.reset_password' do
     context 'with a valid payload' do
       it 'resets the password and returns the user' do
         VCR.use_cassette 'user_management/confirm_password_reset/valid' do
-          user = described_class.confirm_password_reset(
+          user = described_class.reset_password(
             token: 'eEgAgvAE0blvU1zWV3yWVAD22',
             new_password: 'very_cool_new_pa$$word',
           )
@@ -50,7 +50,7 @@ describe WorkOS::UserManagement do
       it 'returns an error' do
         VCR.use_cassette 'user_management/confirm_password_reset/invalid' do
           expect do
-            described_class.confirm_password_reset(
+            described_class.reset_password(
               token: 'bogus_token',
               new_password: 'new_password',
             )
@@ -63,11 +63,11 @@ describe WorkOS::UserManagement do
     end
   end
 
-  describe '.create_password_reset_challenge' do
+  describe '.send_password_reset_email' do
     context 'with a valid payload' do
-      it 'creates a password reset challenge' do
-        VCR.use_cassette 'user_management/create_password_reset_challenge/valid' do
-          user_and_token = described_class.create_password_reset_challenge(
+      it 'sends a password reset email' do
+        VCR.use_cassette 'user_management/send_password_reset_email/valid' do
+          user_and_token = described_class.send_password_reset_email(
             email: 'lucy.lawless@example.com',
             password_reset_url: 'https://example.com/reset',
           )
@@ -80,9 +80,9 @@ describe WorkOS::UserManagement do
 
     context 'with an invalid payload' do
       it 'returns an error' do
-        VCR.use_cassette 'user_management/create_password_reset_challenge/invalid' do
+        VCR.use_cassette 'user_management/send_password_reset_email/invalid' do
           expect do
-            described_class.create_password_reset_challenge(
+            described_class.send_password_reset_email(
               email: 'foo@bar.com',
               password_reset_url: '',
             )

--- a/spec/support/fixtures/vcr_cassettes/user_management/send_password_reset_email/invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/send_password_reset_email/invalid.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.workos.com/users/password_reset_challenge
+    uri: https://api.workos.com/users/send_password_reset_email
     body:
       encoding: UTF-8
-      string: '{"email":"lucy.lawless@example.com","password_reset_url":"https://example.com/reset"}'
+      string: '{"email":"foo@bar.com","password_reset_url":""}'
     headers:
       Content-Type:
       - application/json
@@ -19,23 +19,23 @@ http_interactions:
       - Bearer <API_KEY>
   response:
     status:
-      code: 201
-      message: Created
+      code: 422
+      message: Unprocessable Entity
     headers:
       Date:
-      - Tue, 22 Aug 2023 15:17:54 GMT
+      - Tue, 22 Aug 2023 15:17:55 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '372'
+      - '185'
       Connection:
       - keep-alive
       Cf-Ray:
-      - 7fac15d95b344307-EWR
+      - 7fac15db0d8878d0-EWR
       Cf-Cache-Status:
       - DYNAMIC
       Etag:
-      - W/"174-DVzVYOTqyX3q/AyatAXKdpEIXt0"
+      - W/"b9-MwpjOZS5P8vwlJwJ2Wcz1gYyf6Y"
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
       Vary:
@@ -63,20 +63,21 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 81a9837a-98c2-4672-b676-c0373801bee7
+      - 2b2e336d-0505-43c3-9cc5-4b18841bd31c
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - __cf_bm=umdTRtFxoQN.4ktEcYtcbX1s8jKssJoHPtyhIn6WTks-1692717474-0-AdDIQx1e2bzuszzeXKtvCNRha0v3k93d1P8K+nwBMI2ZwMwU28jXRrsrZibk4tPRFo9wk5sXm2BSyKn+cb8wH+o=;
-        path=/; expires=Tue, 22-Aug-23 15:47:54 GMT; domain=.workos.com; HttpOnly;
+      - __cf_bm=RJi4ZoHPaRE92J8Hyh7jvHe9uc55nnVpOMBuQKZfCb8-1692717475-0-AeTId8BwH1uElzCNWtu+dsvrIY89q9vKqVJ8qd0hEON/AbMwDbsLatlPjyGecK9XamUFzX78taIjJLW5cRIxLF8=;
+        path=/; expires=Tue, 22-Aug-23 15:47:55 GMT; domain=.workos.com; HttpOnly;
         Secure; SameSite=None
-      - __cfruid=18d4d766679a0d25305751659ba8551c12a6ab44-1692717474; path=/; domain=.workos.com;
+      - __cfruid=67a732b1ed159ca5729e30e84c73587d61e22441-1692717475; path=/; domain=.workos.com;
         HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
     body:
       encoding: UTF-8
-      string: '{"token":"rg8vGZMLw94dXmdqAbb42xrwN","user":{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-17T19:43:38.890Z","email_verified":false}}'
+      string: '{"code":"invalid_request_parameters","message":"Validation failed","errors":[{"code":"password_reset_url_string_required","message":"Password
+        Reset Url should be a non-empty string."}]}'
     http_version:
-  recorded_at: Tue, 22 Aug 2023 15:17:54 GMT
+  recorded_at: Tue, 22 Aug 2023 15:17:55 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/send_password_reset_email/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/send_password_reset_email/valid.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.workos.com/users/password_reset_challenge
+    uri: https://api.workos.com/users/send_password_reset_email
     body:
       encoding: UTF-8
-      string: '{"email":"foo@bar.com","password_reset_url":""}'
+      string: '{"email":"lucy.lawless@example.com","password_reset_url":"https://example.com/reset"}'
     headers:
       Content-Type:
       - application/json
@@ -19,23 +19,23 @@ http_interactions:
       - Bearer <API_KEY>
   response:
     status:
-      code: 422
-      message: Unprocessable Entity
+      code: 201
+      message: Created
     headers:
       Date:
-      - Tue, 22 Aug 2023 15:17:55 GMT
+      - Tue, 22 Aug 2023 15:17:54 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '185'
+      - '372'
       Connection:
       - keep-alive
       Cf-Ray:
-      - 7fac15db0d8878d0-EWR
+      - 7fac15d95b344307-EWR
       Cf-Cache-Status:
       - DYNAMIC
       Etag:
-      - W/"b9-MwpjOZS5P8vwlJwJ2Wcz1gYyf6Y"
+      - W/"174-DVzVYOTqyX3q/AyatAXKdpEIXt0"
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
       Vary:
@@ -63,21 +63,20 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 2b2e336d-0505-43c3-9cc5-4b18841bd31c
+      - 81a9837a-98c2-4672-b676-c0373801bee7
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - __cf_bm=RJi4ZoHPaRE92J8Hyh7jvHe9uc55nnVpOMBuQKZfCb8-1692717475-0-AeTId8BwH1uElzCNWtu+dsvrIY89q9vKqVJ8qd0hEON/AbMwDbsLatlPjyGecK9XamUFzX78taIjJLW5cRIxLF8=;
-        path=/; expires=Tue, 22-Aug-23 15:47:55 GMT; domain=.workos.com; HttpOnly;
+      - __cf_bm=umdTRtFxoQN.4ktEcYtcbX1s8jKssJoHPtyhIn6WTks-1692717474-0-AdDIQx1e2bzuszzeXKtvCNRha0v3k93d1P8K+nwBMI2ZwMwU28jXRrsrZibk4tPRFo9wk5sXm2BSyKn+cb8wH+o=;
+        path=/; expires=Tue, 22-Aug-23 15:47:54 GMT; domain=.workos.com; HttpOnly;
         Secure; SameSite=None
-      - __cfruid=67a732b1ed159ca5729e30e84c73587d61e22441-1692717475; path=/; domain=.workos.com;
+      - __cfruid=18d4d766679a0d25305751659ba8551c12a6ab44-1692717474; path=/; domain=.workos.com;
         HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
     body:
       encoding: UTF-8
-      string: '{"code":"invalid_request_parameters","message":"Validation failed","errors":[{"code":"password_reset_url_string_required","message":"Password
-        Reset Url should be a non-empty string."}]}'
+      string: '{"token":"rg8vGZMLw94dXmdqAbb42xrwN","user":{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-17T19:43:38.890Z","email_verified":false}}'
     http_version:
-  recorded_at: Tue, 22 Aug 2023 15:17:55 GMT
+  recorded_at: Tue, 22 Aug 2023 15:17:54 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description
Fixes USRLD-1088
Fixes USRLD-1095

1) Rename `confirm_password_reset` to `reset_password` (note: the payload already returned {user: `user`, token: `token`})
2) Rename `create_password_reset_challenge` to `send_password_reset_email` 
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ X ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
