### PR TITLE
Don't include development executables

### DIFF
--- a/workos.gemspec
+++ b/workos.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
## Description

`workos` gem includes development executables like `console`, `publish` or etc. So, `workos` will install them into bin directory that is part of PATH environmental variables on users machine or production server.

We should remove them because its only for developers of `workos`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
