### PR TITLE
Remove `domains` and `allowProfilesOutsideOrganization` from Organization entity

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (2.12.1)
+    workos (2.16.0)
       sorbet-runtime (~> 0.5)
 
 GEM

--- a/lib/workos/organization.rb
+++ b/lib/workos/organization.rb
@@ -9,7 +9,7 @@ module WorkOS
     include HashProvider
     extend T::Sig
 
-    attr_accessor :id, :domains, :name, :allow_profiles_outside_organization, :created_at, :updated_at
+    attr_accessor :id, :name, :created_at, :updated_at
 
     sig { params(json: String).void }
     def initialize(json)
@@ -17,8 +17,6 @@ module WorkOS
 
       @id = T.let(raw.id, String)
       @name = T.let(raw.name, String)
-      @allow_profiles_outside_organization = T.let(raw.allow_profiles_outside_organization, T::Boolean)
-      @domains = T.let(raw.domains, Array)
       @created_at = T.let(raw.created_at, String)
       @updated_at = T.let(raw.updated_at, String)
     end
@@ -27,8 +25,6 @@ module WorkOS
       {
         id: id,
         name: name,
-        allow_profiles_outside_organization: allow_profiles_outside_organization,
-        domains: domains,
         created_at: created_at,
         updated_at: updated_at,
       }
@@ -47,8 +43,6 @@ module WorkOS
       WorkOS::Types::OrganizationStruct.new(
         id: hash[:id],
         name: hash[:name],
-        allow_profiles_outside_organization: hash[:allow_profiles_outside_organization],
-        domains: hash[:domains],
         created_at: hash[:created_at],
         updated_at: hash[:updated_at],
       )

--- a/lib/workos/organizations.rb
+++ b/lib/workos/organizations.rb
@@ -56,11 +56,7 @@ module WorkOS
       #   WorkOS::Portal.get_organization(id: 'org_02DRA1XNSJDZ19A31F183ECQW9')
       #   => #<WorkOS::Organization:0x00007fb6e4193d20
       #         @id="org_02DRA1XNSJDZ19A31F183ECQW9",
-      #         @name="Foo Corp",
-      #         @domains=
-      #          [{:object=>"organization_domain",
-      #            :id=>"org_domain_01E6PK9N3XMD8RHWF7S66380AR",
-      #            :domain=>"foo-corp.com"}]>
+      #         @name="Foo Corp"
       #
       # @return [WorkOS::Organization]
       sig { params(id: String).returns(WorkOS::Organization) }
@@ -77,27 +73,18 @@ module WorkOS
 
       # Create an organization
       #
-      # @param [Array<String>] domains List of domains that belong to the
-      #  organization
       # @param [String] name A unique, descriptive name for the organization
-      # @param [Boolean, nil] allow_profiles_outside_organization Whether Connections
-      #  within the Organization allow profiles that are outside of the Organization's configured User Email Domains.
-      # @param [String] idempotency_key An idempotency key
       sig do
         params(
-          domains: T::Array[String],
           name: String,
-          allow_profiles_outside_organization: T.nilable(T::Boolean),
           idempotency_key: T.nilable(String),
         ).returns(WorkOS::Organization)
       end
-      def create_organization(domains:, name:, allow_profiles_outside_organization: nil, idempotency_key: nil)
+      def create_organization(name:, idempotency_key: nil)
         request = post_request(
           auth: true,
           body: {
-            domains: domains,
             name: name,
-            allow_profiles_outside_organization: allow_profiles_outside_organization,
           },
           path: '/organizations',
           idempotency_key: idempotency_key,
@@ -112,26 +99,18 @@ module WorkOS
       # Update an organization
       #
       # @param [String] organization Organization unique identifier
-      # @param [Array<String>] domains List of domains that belong to the
-      #  organization
       # @param [String] name A unique, descriptive name for the organization
-      # @param [Boolean, nil] allow_profiles_outside_organization Whether Connections
-      #  within the Organization allow profiles that are outside of the Organization's configured User Email Domains.
       sig do
         params(
           organization: String,
-          domains: T::Array[String],
           name: String,
-          allow_profiles_outside_organization: T.nilable(T::Boolean),
         ).returns(WorkOS::Organization)
       end
-      def update_organization(organization:, domains:, name:, allow_profiles_outside_organization: nil)
+      def update_organization(organization:, name:)
         request = put_request(
           auth: true,
           body: {
-            domains: domains,
             name: name,
-            allow_profiles_outside_organization: allow_profiles_outside_organization,
           },
           path: "/organizations/#{organization}",
         )

--- a/lib/workos/types/organization_struct.rb
+++ b/lib/workos/types/organization_struct.rb
@@ -8,8 +8,6 @@ module WorkOS
     class OrganizationStruct < T::Struct
       const :id, String
       const :name, String
-      const :allow_profiles_outside_organization, T::Boolean
-      const :domains, T::Array[T.untyped]
       const :created_at, String
       const :updated_at, String
     end

--- a/spec/lib/workos/organizations_spec.rb
+++ b/spec/lib/workos/organizations_spec.rb
@@ -10,13 +10,11 @@ describe WorkOS::Organizations do
         it 'creates an organization' do
           VCR.use_cassette 'organization/create' do
             organization = described_class.create_organization(
-              domains: ['example.io'],
               name: 'Test Organization',
             )
 
             expect(organization.id).to eq('org_01FCPEJXEZR4DSBA625YMGQT9N')
             expect(organization.name).to eq('Test Organization')
-            expect(organization.domains.first[:domain]).to eq('example.io')
           end
         end
       end
@@ -26,13 +24,11 @@ describe WorkOS::Organizations do
           it 'creates an organization' do
             VCR.use_cassette 'organization/create_with_idempotency_key' do
               organization = described_class.create_organization(
-                domains: ['example.io'],
                 name: 'Test Organization',
                 idempotency_key: 'key',
               )
 
               expect(organization.name).to eq('Test Organization')
-              expect(organization.domains.first[:domain]).to eq('example.io')
             end
           end
         end
@@ -42,13 +38,11 @@ describe WorkOS::Organizations do
             it 'returns the already created organization' do
               VCR.use_cassette 'organization/create_with_duplicate_idempotency_key_and_payload' do
                 organization1 = described_class.create_organization(
-                  domains: ['example.com'],
                   name: 'Test Organization',
                   idempotency_key: 'foo',
                 )
 
                 organization2 = described_class.create_organization(
-                  domains: ['example.com'],
                   name: 'Test Organization',
                   idempotency_key: 'foo',
                 )
@@ -62,14 +56,12 @@ describe WorkOS::Organizations do
             it 'raises an error' do
               VCR.use_cassette 'organization/create_with_duplicate_idempotency_key_and_different_payload' do
                 described_class.create_organization(
-                  domains: ['example.me'],
                   name: 'Test Organization',
                   idempotency_key: 'bar',
                 )
 
                 expect do
                   described_class.create_organization(
-                    domains: ['example.me'],
                     name: 'Organization Test',
                     idempotency_key: 'bar',
                   )
@@ -89,7 +81,6 @@ describe WorkOS::Organizations do
         VCR.use_cassette 'organization/create_invalid' do
           expect do
             described_class.create_organization(
-              domains: ['example.com'],
               name: 'Test Organization 2',
             )
           end.to raise_error(
@@ -191,7 +182,6 @@ describe WorkOS::Organizations do
 
           expect(organization.id).to eq('org_01F9293WD2PDEEV4Y625XPZVG7')
           expect(organization.name).to eq('Foo Corp')
-          expect(organization.domains.first[:domain]).to eq('foo-corp.com')
         end
       end
     end
@@ -216,13 +206,11 @@ describe WorkOS::Organizations do
         VCR.use_cassette 'organization/update' do
           organization = described_class.update_organization(
             organization: 'org_01F6Q6TFP7RD2PF6J03ANNWDKV',
-            domains: ['example.me'],
             name: 'Test Organization',
           )
 
           expect(organization.id).to eq('org_01F6Q6TFP7RD2PF6J03ANNWDKV')
           expect(organization.name).to eq('Test Organization')
-          expect(organization.domains.first[:domain]).to eq('example.me')
         end
       end
     end


### PR DESCRIPTION
## Description

Breaking change. Removes `domains` and `allowProfilesOutsideOrganization` from Organization entity

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
