### PR TITLE
Update `send_magic_auth_code` method according to latest API reference

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -260,20 +260,20 @@ module WorkOS
 
       # Creates a one-time Magic Auth code and emails it to the user.
       #
-      # @param [String] email_address The email address the one-time code will be sent to.
+      # @param [String] email The email address the one-time code will be sent to.
       #
       # @return WorkOS::UserResponse
       sig do
         params(
-          email_address: String,
+          email: String,
         ).returns(WorkOS::UserResponse)
       end
-      def send_magic_auth_code(email_address:)
+      def send_magic_auth_code(email:)
         response = execute_request(
           request: post_request(
-            path: '/users/magic_auth/send',
+            path: '/user_management/magic_auth/send',
             body: {
-              email_address: email_address,
+              email: email,
             },
             auth: true,
           ),

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -228,7 +228,7 @@ describe WorkOS::UserManagement do
       it 'sends a magic link to the email address' do
         VCR.use_cassette 'user_management/send_magic_auth_code/valid' do
           magic_link_response = described_class.send_magic_auth_code(
-            email_address: 'test@gmail.com',
+            email: 'test@gmail.com',
           )
           expect(magic_link_response.user.id).to eq('user_01H93WD0R0KWF8Q7BK02C0RPYJ')
         end

--- a/spec/support/fixtures/vcr_cassettes/user_management/send_magic_auth_code/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/send_magic_auth_code/valid.yml
@@ -2,10 +2,10 @@
 http_interactions:
   - request:
       method: post
-      uri: https://api.workos.com/users/magic_auth/send
+      uri: https://api.workos.com/user_management/magic_auth/send
       body:
         encoding: UTF-8
-        string: '{"email_address":"test@gmail.com"}'
+        string: '{"email":"test@gmail.com"}'
       headers:
         Content-Type:
           - application/json


### PR DESCRIPTION
## Description

- Updates `send_magic_auth_code` to send `email` instead of deprecated `email_address`
- Updates route to `user_management/magic_auth/send`
- Updates test

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
