### PR TITLE
Refactor Email Verification methods according to latest API reference

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -576,6 +576,52 @@ module WorkOS
         )
       end
 
+      # Sends a verification email to the provided user.
+      #
+      # @param [String] id The unique ID of the User whose email address will be verified.
+      #
+      # @return WorkOS::UserResponse
+      sig do
+        params(
+          id: String,
+        ).returns(WorkOS::UserResponse)
+      end
+      def send_verification_email(id:)
+        response = execute_request(
+          request: post_request(
+            path: "/users/#{id}/send_verification_email",
+            auth: true,
+          ),
+        )
+
+        WorkOS::UserResponse.new(response.body)
+      end
+
+      # Verifies user email using one-time code that was sent to the user.
+      #
+      # @param [String] user_id The unique ID of the User whose email address will be verified.
+      # @param [String] code The one-time code emailed to the user.
+      #
+      # @return WorkOS::UserResponse
+      sig do
+        params(
+          user_id: String,
+          code: String,
+        ).returns(WorkOS::UserResponse)
+      end
+      def verify_email(user_id:, code:)
+        response = execute_request(
+          request: post_request(
+            path: "/users/#{user_id}/verify_email_code",
+            body: {
+              code: code,
+            },
+            auth: true,
+          ),
+        )
+        WorkOS::UserResponse.new(response.body)
+      end
+
       # Resets user password using token that was sent to the user.
       #
       # @param [String] token The token that was sent to the user.
@@ -628,79 +674,6 @@ module WorkOS
         response = execute_request(request: request)
 
         WorkOS::UserAndToken.new(response.body)
-      end
-
-      # Sends a verification email to the provided user.
-      #
-      # @param [String] id The unique ID of the User whose email address will be verified.
-      #
-      # @return WorkOS::UserResponse
-      sig do
-        params(
-          id: String,
-        ).returns(WorkOS::UserResponse)
-      end
-      def send_verification_email(id:)
-        response = execute_request(
-          request: post_request(
-            path: "/users/#{id}/send_verification_email",
-            auth: true,
-          ),
-        )
-
-        WorkOS::UserResponse.new(response.body)
-      end
-
-      # Verifies user email using one-time code that was sent to the user.
-      #
-      # @param [String] user_id The unique ID of the User whose email address will be verified.
-      # @param [String] code The one-time code emailed to the user.
-      #
-      # @return WorkOS::UserResponse
-      sig do
-        params(
-          user_id: String,
-          code: String,
-        ).returns(WorkOS::UserResponse)
-      end
-      def verify_email(user_id:, code:)
-        response = execute_request(
-          request: post_request(
-            path: "/users/#{user_id}/verify_email_code",
-            body: {
-              code: code,
-            },
-            auth: true,
-          ),
-        )
-        WorkOS::UserResponse.new(response.body)
-      end
-
-      # Updates user user password.
-      #
-      # @param [String] id The unique ID of the User.
-      # @param [String] password The new password to set for the user.
-      #
-      # @return WorkOS::User
-
-      sig do
-        params(
-          id: String,
-          password: String,
-        ).returns(WorkOS::User)
-      end
-      def update_user_password(id:, password:)
-        response = execute_request(
-          request: put_request(
-            path: "/users/#{id}/password",
-            body: {
-              password: password,
-            },
-            auth: true,
-          ),
-        )
-
-        WorkOS::User.new(response.body)
       end
 
       private

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -141,8 +141,7 @@ module WorkOS
       #
       # @param [Hash] options
       # @option options [String] email Filter Users by their email.
-      # @option options [String] organization_id Filter Users by the organization
-      #  they are members of.
+      # @option options [String] organization_id Filter Users by the organization they are members of.
       # @option options [String] limit Maximum number of records to return.
       # @option options [String] order The order in which to paginate records
       # @option options [String] before Pagination cursor to receive records

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -506,9 +506,6 @@ module WorkOS
         WorkOS::UserResponse.new(response.body)
       end
 
-
-
-
       # Enroll a user into an authentication factor.
       #
       # @param [String] user_id The id for the user.
@@ -589,7 +586,7 @@ module WorkOS
       def send_verification_email(id:)
         response = execute_request(
           request: post_request(
-            path: "/users/#{id}/send_verification_email",
+            path: "/user_management/users/#{id}/email_verification/send",
             auth: true,
           ),
         )
@@ -612,7 +609,7 @@ module WorkOS
       def verify_email(user_id:, code:)
         response = execute_request(
           request: post_request(
-            path: "/users/#{user_id}/verify_email_code",
+            path: "/user_management/users/#{user_id}/email_verification/confirm",
             body: {
               code: code,
             },

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -118,173 +118,11 @@ module WorkOS
       end
       # rubocop:enable Metrics/ParameterLists
 
-      # Adds a User as a member of the given Organization.
-      #
-      # @param [String] id The unique ID of the User.
-      # @param [String] organization_id Unique identifier of the Organization.
-      #
-      # @return WorkOS::User
-      sig do
-        params(
-          id: String,
-          organization_id: String,
-        ).returns(WorkOS::User)
-      end
-      def add_user_to_organization(id:, organization_id:)
-        response = execute_request(
-          request: post_request(
-            path: "/users/#{id}/organizations",
-            body: {
-              organization_id: organization_id,
-            },
-            auth: true,
-          ),
-        )
-
-        WorkOS::User.new(response.body)
-      end
-
-
-      # Deletes a User
+      # Gets a User
       #
       # @param [String] id The unique ID of the User.
       #
-      # @return [Bool] - returns `true` if successful
-      sig do
-        params(
-          id: String,
-        ).returns(T::Boolean)
-      end
-      def delete_user(id:)
-        response = execute_request(
-          request: delete_request(
-            path: "/user_management/users/#{id}",
-            auth: true,
-          ),
-        )
-
-        response.is_a? Net::HTTPSuccess
-      end
-
-      # Resets user password using token that was sent to the user.
-      #
-      # @param [String] token The token that was sent to the user.
-      # @param [String] new_password The new password to set for the user.
-      #
       # @return WorkOS::User
-      sig do
-        params(
-          token: String,
-          new_password: String,
-        ).returns(WorkOS::User)
-      end
-      def reset_password(token:, new_password:)
-        response = execute_request(
-          request: post_request(
-            path: '/users/password_reset',
-            body: {
-              token: token,
-              new_password: new_password,
-            },
-            auth: true,
-          ),
-        )
-
-        WorkOS::User.new(response.body)
-      end
-
-      # Creates a password reset challenge and emails a password reset link to a user.
-      #
-      # @param [String] email The email of the user that wishes to reset their password.
-      # @param [String] password_reset_url The URL that will be linked to in the email.
-      #
-      # @return WorkOS::UserAndToken
-      sig do
-        params(
-          email: String,
-          password_reset_url: String,
-        ).returns(WorkOS::UserAndToken)
-      end
-      def send_password_reset_email(email:, password_reset_url:)
-        request = post_request(
-          path: '/users/send_password_reset_email',
-          body: {
-            email: email,
-            password_reset_url: password_reset_url,
-          },
-          auth: true,
-        )
-
-        response = execute_request(request: request)
-
-        WorkOS::UserAndToken.new(response.body)
-      end
-
-      # Create a user
-      #
-      # @param [String] email The email address of the user.
-      # @param [String] password The password to set for the user.
-      # @param [String] first_name The user's first name.
-      # @param [String] last_name The user's last name.
-      # @param [Boolean] email_verified Whether the user's email address was previously verified.
-      sig do
-        params(
-          email: String,
-          password: T.nilable(String),
-          first_name: T.nilable(String),
-          last_name: T.nilable(String),
-          email_verified: T.nilable(T::Boolean),
-        ).returns(WorkOS::User)
-      end
-      def create_user(email:, password: nil, first_name: nil, last_name: nil, email_verified: nil)
-        request = post_request(
-          path: '/user_management/users',
-          body: {
-            email: email,
-            password: password,
-            first_name: first_name,
-            last_name: last_name,
-            email_verified: email_verified,
-          },
-          auth: true,
-        )
-
-        response = execute_request(request: request)
-
-        WorkOS::User.new(response.body)
-      end
-
-
-      # Update a user
-      #
-      # @param [String] id of the user.
-      # @param [String] first_name The user's first name.
-      # @param [String] last_name The user's last name.
-      # @param [Boolean] email_verified Whether the user's email address was previously verified.
-      sig do
-        params(
-          id: String,
-          first_name: T.nilable(String),
-          last_name: T.nilable(String),
-          email_verified: T.nilable(T::Boolean),
-        ).returns(WorkOS::User)
-      end
-      def update_user(id:, first_name: nil, last_name: nil, email_verified: nil)
-        request = put_request(
-          path: "/user_management/users/#{id}",
-          body: {
-            first_name: first_name,
-            last_name: last_name,
-            email_verified: email_verified,
-          },
-          auth: true,
-        )
-
-        response = execute_request(request: request)
-
-        WorkOS::User.new(response.body)
-      end
-
       sig do
         params(id: String).returns(WorkOS::User)
       end
@@ -339,124 +177,89 @@ module WorkOS
         )
       end
 
-      # Removes an unmanaged User from the given Organization.
+      # Create a user
       #
-      # @param [String] id The unique ID of the User.
-      # @param [String] organization_id Unique identifier of the Organization.
-      #
-      # @return WorkOS::User
-      sig do
-        params(
-          id: String,
-          organization_id: String,
-        ).returns(WorkOS::User)
-      end
-      def remove_user_from_organization(id:, organization_id:)
-        response = execute_request(
-          request: delete_request(
-            path: "/users/#{id}/organizations/#{organization_id}",
-            auth: true,
-          ),
-        )
-
-        WorkOS::User.new(response.body)
-      end
-
-      # Creates a one-time Magic Auth code and emails it to the user.
-      #
-      # @param [String] email The email address the one-time code will be sent to.
-      #
-      # @return WorkOS::UserResponse
+      # @param [String] email The email address of the user.
+      # @param [String] password The password to set for the user.
+      # @param [String] first_name The user's first name.
+      # @param [String] last_name The user's last name.
+      # @param [Boolean] email_verified Whether the user's email address was previously verified.
       sig do
         params(
           email: String,
-        ).returns(WorkOS::UserResponse)
-      end
-      def send_magic_auth_code(email:)
-        response = execute_request(
-          request: post_request(
-            path: '/user_management/magic_auth/send',
-            body: {
-              email: email,
-            },
-            auth: true,
-          ),
-        )
-
-        WorkOS::UserResponse.new(response.body)
-      end
-
-      # Sends a verification email to the provided user.
-      #
-      # @param [String] id The unique ID of the User whose email address will be verified.
-      #
-      # @return WorkOS::UserResponse
-      sig do
-        params(
-          id: String,
-        ).returns(WorkOS::UserResponse)
-      end
-      def send_verification_email(id:)
-        response = execute_request(
-          request: post_request(
-            path: "/users/#{id}/send_verification_email",
-            auth: true,
-          ),
-        )
-
-        WorkOS::UserResponse.new(response.body)
-      end
-
-      # Verifies user email using one-time code that was sent to the user.
-      #
-      # @param [String] user_id The unique ID of the User whose email address will be verified.
-      # @param [String] code The one-time code emailed to the user.
-      #
-      # @return WorkOS::UserResponse
-      sig do
-        params(
-          user_id: String,
-          code: String,
-        ).returns(WorkOS::UserResponse)
-      end
-      def verify_email(user_id:, code:)
-        response = execute_request(
-          request: post_request(
-            path: "/users/#{user_id}/verify_email_code",
-            body: {
-              code: code,
-            },
-            auth: true,
-          ),
-        )
-        WorkOS::UserResponse.new(response.body)
-      end
-
-      # Updates user user password.
-      #
-      # @param [String] id The unique ID of the User.
-      # @param [String] password The new password to set for the user.
-      #
-      # @return WorkOS::User
-
-      sig do
-        params(
-          id: String,
-          password: String,
+          password: T.nilable(String),
+          first_name: T.nilable(String),
+          last_name: T.nilable(String),
+          email_verified: T.nilable(T::Boolean),
         ).returns(WorkOS::User)
       end
-      def update_user_password(id:, password:)
+      def create_user(email:, password: nil, first_name: nil, last_name: nil, email_verified: nil)
+        request = post_request(
+          path: '/user_management/users',
+          body: {
+            email: email,
+            password: password,
+            first_name: first_name,
+            last_name: last_name,
+            email_verified: email_verified,
+          },
+          auth: true,
+        )
+
+        response = execute_request(request: request)
+
+        WorkOS::User.new(response.body)
+      end
+
+      # Update a user
+      #
+      # @param [String] id of the user.
+      # @param [String] first_name The user's first name.
+      # @param [String] last_name The user's last name.
+      # @param [Boolean] email_verified Whether the user's email address was previously verified.
+      sig do
+        params(
+          id: String,
+          first_name: T.nilable(String),
+          last_name: T.nilable(String),
+          email_verified: T.nilable(T::Boolean),
+        ).returns(WorkOS::User)
+      end
+      def update_user(id:, first_name: nil, last_name: nil, email_verified: nil)
+        request = put_request(
+          path: "/user_management/users/#{id}",
+          body: {
+            first_name: first_name,
+            last_name: last_name,
+            email_verified: email_verified,
+          },
+          auth: true,
+        )
+
+        response = execute_request(request: request)
+
+        WorkOS::User.new(response.body)
+      end
+
+      # Deletes a User
+      #
+      # @param [String] id The unique ID of the User.
+      #
+      # @return [Bool] - returns `true` if successful
+      sig do
+        params(
+          id: String,
+        ).returns(T::Boolean)
+      end
+      def delete_user(id:)
         response = execute_request(
-          request: put_request(
-            path: "/users/#{id}/password",
-            body: {
-              password: password,
-            },
+          request: delete_request(
+            path: "/user_management/users/#{id}",
             auth: true,
           ),
         )
 
-        WorkOS::User.new(response.body)
+        response.is_a? Net::HTTPSuccess
       end
 
       # Authenticates user by email and password.
@@ -679,6 +482,33 @@ module WorkOS
         WorkOS::UserResponse.new(response.body)
       end
 
+      # Creates a one-time Magic Auth code and emails it to the user.
+      #
+      # @param [String] email The email address the one-time code will be sent to.
+      #
+      # @return WorkOS::UserResponse
+      sig do
+        params(
+          email: String,
+        ).returns(WorkOS::UserResponse)
+      end
+      def send_magic_auth_code(email:)
+        response = execute_request(
+          request: post_request(
+            path: '/user_management/magic_auth/send',
+            body: {
+              email: email,
+            },
+            auth: true,
+          ),
+        )
+
+        WorkOS::UserResponse.new(response.body)
+      end
+
+
+
+
       # Enroll a user into an authentication factor.
       #
       # @param [String] user_id The id for the user.
@@ -744,6 +574,133 @@ module WorkOS
           data: auth_factors,
           list_metadata: parsed_response['list_metadata'],
         )
+      end
+
+      # Resets user password using token that was sent to the user.
+      #
+      # @param [String] token The token that was sent to the user.
+      # @param [String] new_password The new password to set for the user.
+      #
+      # @return WorkOS::User
+      sig do
+        params(
+          token: String,
+          new_password: String,
+        ).returns(WorkOS::User)
+      end
+      def reset_password(token:, new_password:)
+        response = execute_request(
+          request: post_request(
+            path: '/users/password_reset',
+            body: {
+              token: token,
+              new_password: new_password,
+            },
+            auth: true,
+          ),
+        )
+
+        WorkOS::User.new(response.body)
+      end
+
+      # Creates a password reset challenge and emails a password reset link to a user.
+      #
+      # @param [String] email The email of the user that wishes to reset their password.
+      # @param [String] password_reset_url The URL that will be linked to in the email.
+      #
+      # @return WorkOS::UserAndToken
+      sig do
+        params(
+          email: String,
+          password_reset_url: String,
+        ).returns(WorkOS::UserAndToken)
+      end
+      def send_password_reset_email(email:, password_reset_url:)
+        request = post_request(
+          path: '/users/send_password_reset_email',
+          body: {
+            email: email,
+            password_reset_url: password_reset_url,
+          },
+          auth: true,
+        )
+
+        response = execute_request(request: request)
+
+        WorkOS::UserAndToken.new(response.body)
+      end
+
+      # Sends a verification email to the provided user.
+      #
+      # @param [String] id The unique ID of the User whose email address will be verified.
+      #
+      # @return WorkOS::UserResponse
+      sig do
+        params(
+          id: String,
+        ).returns(WorkOS::UserResponse)
+      end
+      def send_verification_email(id:)
+        response = execute_request(
+          request: post_request(
+            path: "/users/#{id}/send_verification_email",
+            auth: true,
+          ),
+        )
+
+        WorkOS::UserResponse.new(response.body)
+      end
+
+      # Verifies user email using one-time code that was sent to the user.
+      #
+      # @param [String] user_id The unique ID of the User whose email address will be verified.
+      # @param [String] code The one-time code emailed to the user.
+      #
+      # @return WorkOS::UserResponse
+      sig do
+        params(
+          user_id: String,
+          code: String,
+        ).returns(WorkOS::UserResponse)
+      end
+      def verify_email(user_id:, code:)
+        response = execute_request(
+          request: post_request(
+            path: "/users/#{user_id}/verify_email_code",
+            body: {
+              code: code,
+            },
+            auth: true,
+          ),
+        )
+        WorkOS::UserResponse.new(response.body)
+      end
+
+      # Updates user user password.
+      #
+      # @param [String] id The unique ID of the User.
+      # @param [String] password The new password to set for the user.
+      #
+      # @return WorkOS::User
+
+      sig do
+        params(
+          id: String,
+          password: String,
+        ).returns(WorkOS::User)
+      end
+      def update_user_password(id:, password:)
+        response = execute_request(
+          request: put_request(
+            path: "/users/#{id}/password",
+            body: {
+              password: password,
+            },
+            auth: true,
+          ),
+        )
+
+        WorkOS::User.new(response.body)
       end
 
       private

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -296,6 +296,7 @@ module WorkOS
             },
           ),
         )
+
         WorkOS::UserResponse.new(response.body)
       end
 
@@ -336,6 +337,7 @@ module WorkOS
             },
           ),
         )
+
         WorkOS::UserResponse.new(response.body)
       end
 
@@ -384,6 +386,7 @@ module WorkOS
             },
           ),
         )
+
         WorkOS::UserResponse.new(response.body)
       end
 
@@ -434,6 +437,7 @@ module WorkOS
             },
           ),
         )
+
         WorkOS::UserResponse.new(response.body)
       end
 
@@ -479,6 +483,7 @@ module WorkOS
             },
           ),
         )
+
         WorkOS::UserResponse.new(response.body)
       end
 
@@ -616,6 +621,7 @@ module WorkOS
             auth: true,
           ),
         )
+
         WorkOS::UserResponse.new(response.body)
       end
 

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -219,34 +219,6 @@ describe WorkOS::UserManagement do
     end
   end
 
-  describe '.add_user_to_organization' do
-    context 'with valid paramters' do
-      it 'adds the user to the organization' do
-        VCR.use_cassette 'user_management/add_user_to_organization_valid' do
-          user = described_class.add_user_to_organization(
-            id: 'user_01H7WRJBPAAHX1BYRQHEK7QC4A',
-            organization_id: 'org_01GEQJ8PKE4WH1Q09RSC8CCVJ1',
-          )
-
-          expect(user.id).to eq('user_01H7WRJBPAAHX1BYRQHEK7QC4A')
-        end
-      end
-    end
-
-    context 'with invalid parameters' do
-      it 'returns an error' do
-        VCR.use_cassette 'user_management/add_user_to_organization_invalid' do
-          expect do
-            described_class.add_user_to_organization(
-              id: 'bad_id',
-              organization_id: 'bad_id',
-            )
-          end.to raise_error(WorkOS::APIError, /User not found/)
-        end
-      end
-    end
-  end
-
   describe '.reset_password' do
     context 'with a valid payload' do
       it 'resets the password and returns the user' do
@@ -405,34 +377,6 @@ describe WorkOS::UserManagement do
 
           expect(users.data.size).to eq(1)
           expect(users.data[0].email).to eq('lucy.lawless@example.com')
-        end
-      end
-    end
-  end
-
-  describe '.remove_user_from_organization' do
-    context 'with valid parameters' do
-      it 'removes the user from the organization' do
-        VCR.use_cassette 'user_management/remove_user_from_organization_valid' do
-          user = described_class.remove_user_from_organization(
-            id: 'user_01H7WRJBPAAHX1BYRQHEK7QC4A',
-            organization_id: 'org_01GEQJ8PKE4WH1Q09RSC8CCVJ1',
-          )
-
-          expect(user.id).to eq('user_01H7WRJBPAAHX1BYRQHEK7QC4A')
-        end
-      end
-    end
-
-    context 'with invalid parameters' do
-      it 'returns an error' do
-        VCR.use_cassette 'user_management/remove_user_from_organization_invalid' do
-          expect do
-            described_class.remove_user_from_organization(
-              id: 'bad_id',
-              organization_id: 'bad_id',
-            )
-          end.to raise_error(WorkOS::APIError, /UserOrganizationMembership not found/)
         end
       end
     end

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -513,32 +513,6 @@ describe WorkOS::UserManagement do
       end
     end
   end
-  describe '.update_user_password' do
-    context 'with a valid payload' do
-      it 'updates a user password' do
-        VCR.use_cassette 'user_management/update_user_password/valid' do
-          user = described_class.update_user_password(
-            id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
-            password: '7YtYic00VWcXatPb',
-          )
-          expect(user.id).to eq('user_01H7TVSKS45SDHN5V9XPSM6H44')
-        end
-      end
-
-      context 'with an invalid payload' do
-        it 'returns an error' do
-          VCR.use_cassette 'user_management/update_user_password/invalid' do
-            expect do
-              described_class.update_user_password(
-                id: 'invalid',
-                password: '7YtYic00VWcXatPb',
-              )
-            end.to raise_error(WorkOS::APIError, /User not found/)
-          end
-        end
-      end
-    end
-  end
 
   describe '.authenticate_with_password' do
     context 'with a valid password' do

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -219,101 +219,6 @@ describe WorkOS::UserManagement do
     end
   end
 
-  describe '.reset_password' do
-    context 'with a valid payload' do
-      it 'resets the password and returns the user' do
-        VCR.use_cassette 'user_management/confirm_password_reset/valid' do
-          user = described_class.reset_password(
-            token: 'eEgAgvAE0blvU1zWV3yWVAD22',
-            new_password: 'very_cool_new_pa$$word',
-          )
-
-          expect(user.email).to eq('lucy.lawless@example.com')
-        end
-      end
-    end
-
-    context 'with an invalid payload' do
-      it 'returns an error' do
-        VCR.use_cassette 'user_management/confirm_password_reset/invalid' do
-          expect do
-            described_class.reset_password(
-              token: 'bogus_token',
-              new_password: 'new_password',
-            )
-          end.to raise_error(
-            WorkOS::APIError,
-            /Could not locate user with provided token/,
-          )
-        end
-      end
-    end
-  end
-
-  describe '.send_password_reset_email' do
-    context 'with a valid payload' do
-      it 'sends a password reset email' do
-        VCR.use_cassette 'user_management/send_password_reset_email/valid' do
-          user_and_token = described_class.send_password_reset_email(
-            email: 'lucy.lawless@example.com',
-            password_reset_url: 'https://example.com/reset',
-          )
-
-          expect(user_and_token.user.email).to eq('lucy.lawless@example.com')
-          expect(user_and_token.token.instance_of?(String))
-        end
-      end
-    end
-
-    context 'with an invalid payload' do
-      it 'returns an error' do
-        VCR.use_cassette 'user_management/send_password_reset_email/invalid' do
-          expect do
-            described_class.send_password_reset_email(
-              email: 'foo@bar.com',
-              password_reset_url: '',
-            )
-          end.to raise_error(
-            WorkOS::InvalidRequestError,
-            /password_reset_url_string_required/,
-          )
-        end
-      end
-    end
-  end
-
-  describe '.create_user' do
-    context 'with a valid payload' do
-      it 'creates a user' do
-        VCR.use_cassette 'user_management/create_user_valid' do
-          user = described_class.create_user(
-            email: 'foo@example.com',
-            first_name: 'Foo',
-            last_name: 'Bar',
-            email_verified: true,
-          )
-
-          expect(user.first_name).to eq('Foo')
-          expect(user.last_name).to eq('Bar')
-          expect(user.email).to eq('foo@example.com')
-        end
-      end
-
-      context 'with an invalid payload' do
-        it 'returns an error' do
-          VCR.use_cassette 'user_management/create_user_invalid' do
-            expect do
-              described_class.create_user(email: '')
-            end.to raise_error(
-              WorkOS::InvalidRequestError,
-              /email_string_required/,
-            )
-          end
-        end
-      end
-    end
-  end
-
   describe '.get_user' do
     context 'with a valid id' do
       it 'returns a user' do
@@ -382,81 +287,32 @@ describe WorkOS::UserManagement do
     end
   end
 
-  describe '.send_magic_auth_code' do
-    context 'with valid parameters' do
-      it 'sends a magic link to the email address' do
-        VCR.use_cassette 'user_management/send_magic_auth_code/valid' do
-          magic_link_response = described_class.send_magic_auth_code(
-            email: 'test@gmail.com',
+  describe '.create_user' do
+    context 'with a valid payload' do
+      it 'creates a user' do
+        VCR.use_cassette 'user_management/create_user_valid' do
+          user = described_class.create_user(
+            email: 'foo@example.com',
+            first_name: 'Foo',
+            last_name: 'Bar',
+            email_verified: true,
           )
-          expect(magic_link_response.user.id).to eq('user_01H93WD0R0KWF8Q7BK02C0RPYJ')
+
+          expect(user.first_name).to eq('Foo')
+          expect(user.last_name).to eq('Bar')
+          expect(user.email).to eq('foo@example.com')
         end
       end
-    end
-  end
 
-  describe '.send_verification_email' do
-    context 'with valid parameters' do
-      it 'sends an email to that user and the magic auth challenge' do
-        VCR.use_cassette 'user_management/send_verification_email/valid' do
-          verification_response = described_class.send_verification_email(
-            id: 'user_01H93WD0R0KWF8Q7BK02C0RPYJ',
-          )
-          expect(verification_response.user.id).to eq('user_01H93WD0R0KWF8Q7BK02C0RPYJ')
-        end
-      end
-    end
-
-    context 'when the user does not exist' do
-      it 'returns an error' do
-        VCR.use_cassette 'user_management/send_verification_email/invalid' do
-          expect do
-            described_class.send_verification_email(
-              id: 'bad_id',
+      context 'with an invalid payload' do
+        it 'returns an error' do
+          VCR.use_cassette 'user_management/create_user_invalid' do
+            expect do
+              described_class.create_user(email: '')
+            end.to raise_error(
+              WorkOS::InvalidRequestError,
+              /email_string_required/,
             )
-          end.to raise_error(WorkOS::APIError, /User not found/)
-        end
-      end
-    end
-  end
-
-  describe '.verify_email' do
-    context 'with valid parameters' do
-      it 'verifies the email and returns the user' do
-        VCR.use_cassette 'user_management/verify_email/valid' do
-          verify_response = described_class.verify_email(
-            code: '333495',
-            user_id: 'user_01H968BR1R84DSPYS9QR5PM6RZ',
-          )
-
-          expect(verify_response.user.id).to eq('user_01H968BR1R84DSPYS9QR5PM6RZ')
-        end
-      end
-    end
-
-    context 'with invalid parameters' do
-      context 'when the id does not exist' do
-        it 'raises an error' do
-          VCR.use_cassette 'user_management/verify_email/invalid_magic_auth_challenge' do
-            expect do
-              described_class.verify_email(
-                code: '659770',
-                user_id: 'bad_id',
-              )
-            end.to raise_error(WorkOS::APIError, /User not found/)
-          end
-        end
-      end
-
-      context 'when the code is incorrect' do
-        it 'raises an error' do
-          VCR.use_cassette 'user_management/verify_email/invalid_code' do
-            expect do
-              described_class.verify_email(
-                code: '000000',
-                user_id: 'user_01H93WD0R0KWF8Q7BK02C0RPYJ',
-              )
-            end.to raise_error(WorkOS::InvalidRequestError, /Email verification code is incorrect/)
           end
         end
       end
@@ -490,6 +346,7 @@ describe WorkOS::UserManagement do
       end
     end
   end
+
   describe '.delete_user' do
     context 'with a valid id' do
       it 'returns true' do
@@ -677,6 +534,19 @@ describe WorkOS::UserManagement do
     end
   end
 
+  describe '.send_magic_auth_code' do
+    context 'with valid parameters' do
+      it 'sends a magic link to the email address' do
+        VCR.use_cassette 'user_management/send_magic_auth_code/valid' do
+          magic_link_response = described_class.send_magic_auth_code(
+            email: 'test@gmail.com',
+          )
+          expect(magic_link_response.user.id).to eq('user_01H93WD0R0KWF8Q7BK02C0RPYJ')
+        end
+      end
+    end
+  end
+
   describe '.enroll_auth_factor' do
     context 'with a valid user_id and auth factor type' do
       it 'returns an auth factor and challenge' do
@@ -738,6 +608,137 @@ describe WorkOS::UserManagement do
               user_id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
             )
           end.to raise_error(WorkOS::InvalidRequestError, /Status 400/)
+        end
+      end
+    end
+  end
+
+  describe '.send_verification_email' do
+    context 'with valid parameters' do
+      it 'sends an email to that user and the magic auth challenge' do
+        VCR.use_cassette 'user_management/send_verification_email/valid' do
+          verification_response = described_class.send_verification_email(
+            id: 'user_01H93WD0R0KWF8Q7BK02C0RPYJ',
+          )
+          expect(verification_response.user.id).to eq('user_01H93WD0R0KWF8Q7BK02C0RPYJ')
+        end
+      end
+    end
+
+    context 'when the user does not exist' do
+      it 'returns an error' do
+        VCR.use_cassette 'user_management/send_verification_email/invalid' do
+          expect do
+            described_class.send_verification_email(
+              id: 'bad_id',
+            )
+          end.to raise_error(WorkOS::APIError, /User not found/)
+        end
+      end
+    end
+  end
+
+  describe '.verify_email' do
+    context 'with valid parameters' do
+      it 'verifies the email and returns the user' do
+        VCR.use_cassette 'user_management/verify_email/valid' do
+          verify_response = described_class.verify_email(
+            code: '333495',
+            user_id: 'user_01H968BR1R84DSPYS9QR5PM6RZ',
+          )
+
+          expect(verify_response.user.id).to eq('user_01H968BR1R84DSPYS9QR5PM6RZ')
+        end
+      end
+    end
+
+    context 'with invalid parameters' do
+      context 'when the id does not exist' do
+        it 'raises an error' do
+          VCR.use_cassette 'user_management/verify_email/invalid_magic_auth_challenge' do
+            expect do
+              described_class.verify_email(
+                code: '659770',
+                user_id: 'bad_id',
+              )
+            end.to raise_error(WorkOS::APIError, /User not found/)
+          end
+        end
+      end
+
+      context 'when the code is incorrect' do
+        it 'raises an error' do
+          VCR.use_cassette 'user_management/verify_email/invalid_code' do
+            expect do
+              described_class.verify_email(
+                code: '000000',
+                user_id: 'user_01H93WD0R0KWF8Q7BK02C0RPYJ',
+              )
+            end.to raise_error(WorkOS::InvalidRequestError, /Email verification code is incorrect/)
+          end
+        end
+      end
+    end
+  end
+
+  describe '.reset_password' do
+    context 'with a valid payload' do
+      it 'resets the password and returns the user' do
+        VCR.use_cassette 'user_management/confirm_password_reset/valid' do
+          user = described_class.reset_password(
+            token: 'eEgAgvAE0blvU1zWV3yWVAD22',
+            new_password: 'very_cool_new_pa$$word',
+          )
+
+          expect(user.email).to eq('lucy.lawless@example.com')
+        end
+      end
+    end
+
+    context 'with an invalid payload' do
+      it 'returns an error' do
+        VCR.use_cassette 'user_management/confirm_password_reset/invalid' do
+          expect do
+            described_class.reset_password(
+              token: 'bogus_token',
+              new_password: 'new_password',
+            )
+          end.to raise_error(
+            WorkOS::APIError,
+            /Could not locate user with provided token/,
+          )
+        end
+      end
+    end
+  end
+
+  describe '.send_password_reset_email' do
+    context 'with a valid payload' do
+      it 'sends a password reset email' do
+        VCR.use_cassette 'user_management/send_password_reset_email/valid' do
+          user_and_token = described_class.send_password_reset_email(
+            email: 'lucy.lawless@example.com',
+            password_reset_url: 'https://example.com/reset',
+          )
+
+          expect(user_and_token.user.email).to eq('lucy.lawless@example.com')
+          expect(user_and_token.token.instance_of?(String))
+        end
+      end
+    end
+
+    context 'with an invalid payload' do
+      it 'returns an error' do
+        VCR.use_cassette 'user_management/send_password_reset_email/invalid' do
+          expect do
+            described_class.send_password_reset_email(
+              email: 'foo@bar.com',
+              password_reset_url: '',
+            )
+          end.to raise_error(
+            WorkOS::InvalidRequestError,
+            /password_reset_url_string_required/,
+          )
         end
       end
     end

--- a/spec/support/fixtures/vcr_cassettes/user_management/send_verification_email/invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/send_verification_email/invalid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.workos.com/users/bad_id/send_verification_email
+    uri: https://api.workos.com/user_management/users/bad_id/email_verification/send
     body:
       encoding: UTF-8
       string: ''

--- a/spec/support/fixtures/vcr_cassettes/user_management/send_verification_email/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/send_verification_email/valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: post
-      uri: https://api.workos.com/users/user_01H93WD0R0KWF8Q7BK02C0RPYJ/send_verification_email
+      uri: https://api.workos.com/user_management/users/user_01H93WD0R0KWF8Q7BK02C0RPYJ/email_verification/send
       body:
         encoding: UTF-8
         string: ""

--- a/spec/support/fixtures/vcr_cassettes/user_management/verify_email/invalid_code.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/verify_email/invalid_code.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.workos.com/users/user_01H93WD0R0KWF8Q7BK02C0RPYJ/verify_email_code
+    uri: https://api.workos.com/user_management/users/user_01H93WD0R0KWF8Q7BK02C0RPYJ/email_verification/confirm
     body:
       encoding: UTF-8
       string: '{"code":"000000"}'

--- a/spec/support/fixtures/vcr_cassettes/user_management/verify_email/invalid_magic_auth_challenge.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/verify_email/invalid_magic_auth_challenge.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.workos.com/users/bad_id/verify_email_code
+    uri: https://api.workos.com/user_management/users/bad_id/email_verification/confirm
     body:
       encoding: UTF-8
       string: '{"code":"966451"}'

--- a/spec/support/fixtures/vcr_cassettes/user_management/verify_email/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/verify_email/valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: post
-      uri: https://api.workos.com/users/user_01H968BR1R84DSPYS9QR5PM6RZ/verify_email_code
+      uri: https://api.workos.com/user_management/users/user_01H968BR1R84DSPYS9QR5PM6RZ/email_verification/confirm
       body:
         encoding: UTF-8
         string: '{"code":"333495"}'


### PR DESCRIPTION
## Description

- Re-order methods according to API reference 
- Update `send_verification_email` and `verify_email` methods 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
