### PR TITLE
Update Password Reset methods according to latest API reference

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -624,33 +624,6 @@ module WorkOS
         WorkOS::UserResponse.new(response.body)
       end
 
-      # Resets user password using token that was sent to the user.
-      #
-      # @param [String] token The token that was sent to the user.
-      # @param [String] new_password The new password to set for the user.
-      #
-      # @return WorkOS::User
-      sig do
-        params(
-          token: String,
-          new_password: String,
-        ).returns(WorkOS::User)
-      end
-      def reset_password(token:, new_password:)
-        response = execute_request(
-          request: post_request(
-            path: '/users/password_reset',
-            body: {
-              token: token,
-              new_password: new_password,
-            },
-            auth: true,
-          ),
-        )
-
-        WorkOS::User.new(response.body)
-      end
-
       # Creates a password reset challenge and emails a password reset link to a user.
       #
       # @param [String] email The email of the user that wishes to reset their password.
@@ -665,7 +638,7 @@ module WorkOS
       end
       def send_password_reset_email(email:, password_reset_url:)
         request = post_request(
-          path: '/users/send_password_reset_email',
+          path: '/user_management/password_reset/send',
           body: {
             email: email,
             password_reset_url: password_reset_url,

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -629,12 +629,12 @@ module WorkOS
       # @param [String] email The email of the user that wishes to reset their password.
       # @param [String] password_reset_url The URL that will be linked to in the email.
       #
-      # @return WorkOS::UserAndToken
+      # @return [Bool] - returns `true` if successful
       sig do
         params(
           email: String,
           password_reset_url: String,
-        ).returns(WorkOS::UserAndToken)
+        ).returns(T::Boolean)
       end
       def send_password_reset_email(email:, password_reset_url:)
         request = post_request(
@@ -648,7 +648,7 @@ module WorkOS
 
         response = execute_request(request: request)
 
-        WorkOS::UserAndToken.new(response.body)
+        response.is_a? Net::HTTPSuccess
       end
 
       # Resets user password using token that was sent to the user.

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -651,6 +651,33 @@ module WorkOS
         WorkOS::UserAndToken.new(response.body)
       end
 
+      # Resets user password using token that was sent to the user.
+      #
+      # @param [String] token The token that was sent to the user.
+      # @param [String] new_password The new password to set for the user.
+      #
+      # @return WorkOS::User
+      sig do
+        params(
+          token: String,
+          new_password: String,
+        ).returns(WorkOS::User)
+      end
+      def reset_password(token:, new_password:)
+        response = execute_request(
+          request: post_request(
+            path: '/user_management/password_reset/confirm',
+            body: {
+              token: token,
+              new_password: new_password,
+            },
+            auth: true,
+          ),
+        )
+
+        WorkOS::User.new(response.body)
+      end
+
       private
 
       sig do

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -681,37 +681,6 @@ describe WorkOS::UserManagement do
     end
   end
 
-  describe '.reset_password' do
-    context 'with a valid payload' do
-      it 'resets the password and returns the user' do
-        VCR.use_cassette 'user_management/confirm_password_reset/valid' do
-          user = described_class.reset_password(
-            token: 'eEgAgvAE0blvU1zWV3yWVAD22',
-            new_password: 'very_cool_new_pa$$word',
-          )
-
-          expect(user.email).to eq('lucy.lawless@example.com')
-        end
-      end
-    end
-
-    context 'with an invalid payload' do
-      it 'returns an error' do
-        VCR.use_cassette 'user_management/confirm_password_reset/invalid' do
-          expect do
-            described_class.reset_password(
-              token: 'bogus_token',
-              new_password: 'new_password',
-            )
-          end.to raise_error(
-            WorkOS::APIError,
-            /Could not locate user with provided token/,
-          )
-        end
-      end
-    end
-  end
-
   describe '.send_password_reset_email' do
     context 'with a valid payload' do
       it 'sends a password reset email' do

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -685,13 +685,12 @@ describe WorkOS::UserManagement do
     context 'with a valid payload' do
       it 'sends a password reset email' do
         VCR.use_cassette 'user_management/send_password_reset_email/valid' do
-          user_and_token = described_class.send_password_reset_email(
+          response = described_class.send_password_reset_email(
             email: 'lucy.lawless@example.com',
             password_reset_url: 'https://example.com/reset',
           )
 
-          expect(user_and_token.user.email).to eq('lucy.lawless@example.com')
-          expect(user_and_token.token.instance_of?(String))
+          expect(response).to be(true)
         end
       end
     end

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -712,4 +712,35 @@ describe WorkOS::UserManagement do
       end
     end
   end
+
+  describe '.reset_password' do
+    context 'with a valid payload' do
+      it 'resets the password and returns the user' do
+        VCR.use_cassette 'user_management/reset_password/valid' do
+          user = described_class.reset_password(
+            token: 'eEgAgvAE0blvU1zWV3yWVAD22',
+            new_password: 'very_cool_new_pa$$word',
+          )
+
+          expect(user.email).to eq('lucy.lawless@example.com')
+        end
+      end
+    end
+
+    context 'with an invalid payload' do
+      it 'returns an error' do
+        VCR.use_cassette 'user_management/reset_password/invalid' do
+          expect do
+            described_class.reset_password(
+              token: 'bogus_token',
+              new_password: 'new_password',
+            )
+          end.to raise_error(
+            WorkOS::APIError,
+            /Could not locate user with provided token/,
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/support/fixtures/vcr_cassettes/user_management/confirm_password_reset/invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/confirm_password_reset/invalid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.workos.com/users/password_reset
+    uri: https://api.workos.com/user_management/password_reset/confirm
     body:
       encoding: UTF-8
       string: '{"token":"bogus_token","new_password":"new_password"}'
@@ -14,28 +14,28 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - WorkOS; ruby/3.0.2; arm64-darwin22; v2.16.0
+      - WorkOS; ruby/3.0.2; arm64-darwin23; v2.16.0
       Authorization:
-      - Bearer <API_KEY>
+      - 'Bearer '
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
       Date:
-      - Tue, 22 Aug 2023 20:37:23 GMT
+      - Sat, 25 Nov 2023 21:46:08 GMT
       Content-Type:
       - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '26'
       Connection:
       - keep-alive
       Cf-Ray:
-      - 7fade9d76fd5c443-EWR
+      - 82bd15298d6aa562-GRU
       Cf-Cache-Status:
       - DYNAMIC
       Etag:
-      - W/"6e-ewNsQiFn+97Q628gVxOcxYY8/4k"
+      - W/"1a-pljHtlo127JYJR4E/RYOPb6ucbw"
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
       Vary:
@@ -63,20 +63,20 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 6de35dcb-7631-4ffe-95f7-2e0f45fa4fe0
+      - f1a0b3f8-67fb-4885-81f8-18a40a4dd2c5
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - __cf_bm=3YpjDFO_KeR0V.HElgb4nKH0.Ixe_Kr3uSwR.sbSmsM-1692736643-0-AV69ETcL8wiAv3YIQ5mB+YssIizhLxQx5gSh4jLBpVKsr/fLS5pivrU+7BBuCSl8xrrR4HGvB8ijEIYiYyF0P7I=;
-        path=/; expires=Tue, 22-Aug-23 21:07:23 GMT; domain=.workos.com; HttpOnly;
+      - __cf_bm=bOqLLKZ3OqpZ3OPfDa2w7klrkJKdkS9Y9apX.l.nSYU-1700948768-0-AbdBkjCZaXQcftSAC9N6KB1K0k2BGHaZZkJ2fqyngyDfWsGZiI9MnCe7HXBU8jhuevFp6MC8kxfWFY3tgW2hFZI=;
+        path=/; expires=Sat, 25-Nov-23 22:16:08 GMT; domain=.workos.com; HttpOnly;
         Secure; SameSite=None
-      - __cfruid=d094d0e9ed722cc5178c6d8aa368d9761b1b2e5c-1692736643; path=/; domain=.workos.com;
+      - __cfruid=7aeaa81f9fe2d2f5c00011adcc897a137e871796-1700948768; path=/; domain=.workos.com;
         HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
     body:
-      encoding: ASCII-8BIT
-      string: '{"message":"Could not locate user with provided token: ''bogus_token''","code":"password_reset_token_not_found"}'
+      encoding: UTF-8
+      string: '{"message":"Unauthorized"}'
     http_version:
-  recorded_at: Tue, 22 Aug 2023 20:37:23 GMT
+  recorded_at: Sat, 25 Nov 2023 21:46:08 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/reset_password/invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/reset_password/invalid.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.workos.com/user_management/password_reset/confirm
     body:
       encoding: UTF-8
-      string: '{"token":"eEgAgvAE0blvU1zWV3yWVAD22","new_password":"very_cool_new_pa$$word"}'
+      string: '{"token":"bogus_token","new_password":"new_password"}'
     headers:
       Content-Type:
       - application/json
@@ -14,28 +14,28 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - WorkOS; ruby/3.0.2; arm64-darwin23; v2.16.0
+      - WorkOS; ruby/3.0.2; arm64-darwin22; v2.16.0
       Authorization:
-      - 'Bearer '
+      - Bearer <API_KEY>
   response:
     status:
-      code: 401
-      message: Unauthorized
+      code: 404
+      message: Not Found
     headers:
       Date:
-      - Sat, 25 Nov 2023 21:46:08 GMT
+      - Tue, 22 Aug 2023 20:37:23 GMT
       Content-Type:
       - application/json; charset=utf-8
-      Content-Length:
-      - '26'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Cf-Ray:
-      - 82bd15254f97a56e-GRU
+      - 7fade9d76fd5c443-EWR
       Cf-Cache-Status:
       - DYNAMIC
       Etag:
-      - W/"1a-pljHtlo127JYJR4E/RYOPb6ucbw"
+      - W/"6e-ewNsQiFn+97Q628gVxOcxYY8/4k"
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
       Vary:
@@ -63,20 +63,20 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 7b813ca7-add6-4a7f-a7de-62b6a888543a
+      - 6de35dcb-7631-4ffe-95f7-2e0f45fa4fe0
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - __cf_bm=hmCZ.6OoiqzmwuUv6cpz.7XUdZcGTwNtfljW2v0dgPU-1700948768-0-ARWxWopNivTNFw8yWMnXuWh02wkLM9ahNWpAbgpDrKDdgzjMG7NPI1AQS81qrJakN4McyBudLtMYxrrVSoLm0I0=;
-        path=/; expires=Sat, 25-Nov-23 22:16:08 GMT; domain=.workos.com; HttpOnly;
+      - __cf_bm=3YpjDFO_KeR0V.HElgb4nKH0.Ixe_Kr3uSwR.sbSmsM-1692736643-0-AV69ETcL8wiAv3YIQ5mB+YssIizhLxQx5gSh4jLBpVKsr/fLS5pivrU+7BBuCSl8xrrR4HGvB8ijEIYiYyF0P7I=;
+        path=/; expires=Tue, 22-Aug-23 21:07:23 GMT; domain=.workos.com; HttpOnly;
         Secure; SameSite=None
-      - __cfruid=7aeaa81f9fe2d2f5c00011adcc897a137e871796-1700948768; path=/; domain=.workos.com;
+      - __cfruid=d094d0e9ed722cc5178c6d8aa368d9761b1b2e5c-1692736643; path=/; domain=.workos.com;
         HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
     body:
-      encoding: UTF-8
-      string: '{"message":"Unauthorized"}'
+      encoding: ASCII-8BIT
+      string: '{"message":"Could not locate user with provided token: ''bogus_token''","code":"password_reset_token_not_found"}'
     http_version:
-  recorded_at: Sat, 25 Nov 2023 21:46:07 GMT
+  recorded_at: Tue, 22 Aug 2023 20:37:23 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/reset_password/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/reset_password/valid.yml
@@ -14,28 +14,28 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - WorkOS; ruby/3.0.2; arm64-darwin23; v2.16.0
+      - WorkOS; ruby/3.0.2; arm64-darwin22; v2.16.0
       Authorization:
-      - 'Bearer '
+      - Bearer <API_KEY>
   response:
     status:
-      code: 401
-      message: Unauthorized
+      code: 201
+      message: Created
     headers:
       Date:
-      - Sat, 25 Nov 2023 21:46:08 GMT
+      - Tue, 22 Aug 2023 20:35:40 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '26'
+      - '327'
       Connection:
       - keep-alive
       Cf-Ray:
-      - 82bd15254f97a56e-GRU
+      - 7fade751ac5ec468-EWR
       Cf-Cache-Status:
       - DYNAMIC
       Etag:
-      - W/"1a-pljHtlo127JYJR4E/RYOPb6ucbw"
+      - W/"147-j3/W7XHKx6tuvwZhBiKvsK7XVG4"
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
       Vary:
@@ -63,20 +63,20 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 7b813ca7-add6-4a7f-a7de-62b6a888543a
+      - c921b63e-c9ec-4397-bfc4-cfb7a740880d
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - __cf_bm=hmCZ.6OoiqzmwuUv6cpz.7XUdZcGTwNtfljW2v0dgPU-1700948768-0-ARWxWopNivTNFw8yWMnXuWh02wkLM9ahNWpAbgpDrKDdgzjMG7NPI1AQS81qrJakN4McyBudLtMYxrrVSoLm0I0=;
-        path=/; expires=Sat, 25-Nov-23 22:16:08 GMT; domain=.workos.com; HttpOnly;
+      - __cf_bm=HGGZ5slgbvhqsmhXQpwInebeKVPg5gvChLNIPC_O46g-1692736540-0-AbnpCKW5I+JexTqMQiWhaBv7h2Ohf7MQTC+2iUFEVvL/NLbuOx4BWhvPhUN3TM8jUgIuAcldYOWjKuxfZfVL+rE=;
+        path=/; expires=Tue, 22-Aug-23 21:05:40 GMT; domain=.workos.com; HttpOnly;
         Secure; SameSite=None
-      - __cfruid=7aeaa81f9fe2d2f5c00011adcc897a137e871796-1700948768; path=/; domain=.workos.com;
+      - __cfruid=d4db2e7c2f1e661b363d5566a7aa592cc5e1710e-1692736540; path=/; domain=.workos.com;
         HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
     body:
       encoding: UTF-8
-      string: '{"message":"Unauthorized"}'
+      string: '{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-22T20:34:49.277Z","email_verified":false}'
     http_version:
-  recorded_at: Sat, 25 Nov 2023 21:46:07 GMT
+  recorded_at: Tue, 22 Aug 2023 20:35:40 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/send_password_reset_email/invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/send_password_reset_email/invalid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.workos.com/users/send_password_reset_email
+    uri: https://api.workos.com/user_management/password_reset/send
     body:
       encoding: UTF-8
       string: '{"email":"foo@bar.com","password_reset_url":""}'

--- a/spec/support/fixtures/vcr_cassettes/user_management/send_password_reset_email/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/send_password_reset_email/valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.workos.com/users/send_password_reset_email
+    uri: https://api.workos.com/user_management/password_reset/send
     body:
       encoding: UTF-8
       string: '{"email":"lucy.lawless@example.com","password_reset_url":"https://example.com/reset"}'

--- a/spec/support/fixtures/vcr_cassettes/user_management/send_password_reset_email/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/send_password_reset_email/valid.yml
@@ -76,7 +76,7 @@ http_interactions:
       - cloudflare
     body:
       encoding: UTF-8
-      string: '{"token":"rg8vGZMLw94dXmdqAbb42xrwN","user":{"object":"user","id":"user_01H7WRJBPAAHX1BYRQHEK7QC4A","email":"lucy.lawless@example.com","first_name":"Lucy","last_name":"Lawless","created_at":"2023-08-15T14:11:04.519Z","updated_at":"2023-08-17T19:43:38.890Z","email_verified":false}}'
+      string: ''
     http_version:
   recorded_at: Tue, 22 Aug 2023 15:17:54 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description

Refactoring `send_password_reset_email` & `reset_password` + updating tests

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
