### PR TITLE
Update `authenticate_with_magic_auth` to use the `email` instead of `user_id` parameter

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -355,7 +355,7 @@ module WorkOS
       sig do
         params(
           code: String,
-          user_id: String,
+          email: String,
           client_id: String,
           ip_address: T.nilable(String),
           user_agent: T.nilable(String),
@@ -364,7 +364,7 @@ module WorkOS
       end
       def authenticate_with_magic_auth(
         code:,
-        user_id:,
+        email:,
         client_id:,
         ip_address: nil,
         user_agent: nil,
@@ -375,7 +375,7 @@ module WorkOS
             path: '/user_management/authenticate',
             body: {
               code: code,
-              user_id: user_id,
+              email: email,
               client_id: client_id,
               client_secret: WorkOS.config.key!,
               ip_address: ip_address,

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -343,7 +343,7 @@ module WorkOS
       # Authenticates user by Magic Auth Code.
       #
       # @param [String] code The one-time code that was emailed to the user.
-      # @param [String] user_id The unique ID of the User who will be authenticated.
+      # @param [String] email The email address of the user.
       # @param [String] client_id The WorkOS client ID for the environment.
       # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
       # @param [String] link_authorization_code Used to link an OAuth profile to an existing user,

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -442,7 +442,7 @@ describe WorkOS::UserManagement do
           authentication_response = WorkOS::UserManagement.authenticate_with_magic_auth(
             code: '452079',
             client_id: 'project_01EGKAEB7G5N88E83MF99J785F',
-            user_id: 'user_01H93WD0R0KWF8Q7BK02C0RPYJ',
+            email: 'test@workos.com',
             ip_address: '200.240.210.16',
             user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36',
           )
@@ -458,7 +458,7 @@ describe WorkOS::UserManagement do
             WorkOS::UserManagement.authenticate_with_magic_auth(
               code: 'invalid',
               client_id: 'client_123',
-              user_id: 'user_01H93WD0R0KWF8Q7BK02C0RPY',
+              email: 'test@workos.com',
             )
           end.to raise_error(WorkOS::APIError, /User not found/)
         end

--- a/spec/support/fixtures/vcr_cassettes/user_management/authenticate_with_magic_auth/invalid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/authenticate_with_magic_auth/invalid.yml
@@ -6,7 +6,7 @@ http_interactions:
       body:
         encoding: UTF-8
         string:
-          '{"code":"invalid","user_id":"user_01H93WD0R0KWF8Q7BK02C0RPY","client_id":"client_123","client_secret":"<API_KEY>","ip_address":"200.240.210.16","user_agent":"Mozilla/5.0
+          '{"code":"invalid","email":"test@workos.com","client_id":"client_123","client_secret":"<API_KEY>","ip_address":"200.240.210.16","user_agent":"Mozilla/5.0
           (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36","grant_type":"urn:workos:oauth:grant-type:magic-auth:code"}'
       headers:
         Content-Type:

--- a/spec/support/fixtures/vcr_cassettes/user_management/authenticate_with_magic_auth/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/authenticate_with_magic_auth/valid.yml
@@ -6,7 +6,7 @@ http_interactions:
       body:
         encoding: UTF-8
         string:
-          '{"code":"452079","user_id":"user_01H93WD0R0KWF8Q7BK02C0RPYJ","client_id":"client_123","client_secret":"<API_KEY>","ip_address":"200.240.210.16","user_agent":"Mozilla/5.0
+          '{"code":"452079","email":"test@workos.com","client_id":"client_123","client_secret":"<API_KEY>","ip_address":"200.240.210.16","user_agent":"Mozilla/5.0
           (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36","grant_type":"urn:workos:oauth:grant-type:magic-auth:code"}'
       headers:
         Content-Type:


### PR DESCRIPTION
## Description

- Updates the `authenticate_with_magic_auth` to receive `email` instead of `user_id` 
- Updates tests

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
