### PR TITLE
Remove user from `/magic_auth/send` response

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -490,11 +490,11 @@ module WorkOS
       #
       # @param [String] email The email address the one-time code will be sent to.
       #
-      # @return WorkOS::UserResponse
+      # @return [Bool] - returns `true` if successful
       sig do
         params(
           email: String,
-        ).returns(WorkOS::UserResponse)
+        ).returns(T::Boolean)
       end
       def send_magic_auth_code(email:)
         response = execute_request(
@@ -507,7 +507,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::UserResponse.new(response.body)
+        response.is_a? Net::HTTPSuccess
       end
 
       # Enroll a user into an authentication factor.

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -541,7 +541,7 @@ describe WorkOS::UserManagement do
           magic_link_response = described_class.send_magic_auth_code(
             email: 'test@gmail.com',
           )
-          expect(magic_link_response.user.id).to eq('user_01H93WD0R0KWF8Q7BK02C0RPYJ')
+          expect(magic_link_response).to be(true)
         end
       end
     end

--- a/spec/support/fixtures/vcr_cassettes/user_management/send_magic_auth_code/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/send_magic_auth_code/valid.yml
@@ -76,7 +76,7 @@ http_interactions:
           - cloudflare
       body:
         encoding: ASCII-8BIT
-        string: '{"user":{"object":"user","id":"user_01H93WD0R0KWF8Q7BK02C0RPYJ","email":"test@gmail.com","email_verified":true,"first_name":"Adam","last_name":"Zinder","created_at":"2023-08-30T18:48:26.517Z","updated_at":"2023-08-30T18:58:00.821Z","user_type":"unmanaged","email_verified_at":"2023-08-30T18:58:00.915Z","google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}}'
+        string: ''
       http_version:
     recorded_at: Thu, 31 Aug 2023 16:32:01 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description

Removes user struct from `/magic_auth/send` return type since the API response is empty. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
