### PR TITLE
Add password, password_hash and password_hash_type to update_user 

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -220,7 +220,7 @@ module WorkOS
       # @option update_hash [Boolean] email_verified Whether the user's email address was previously verified.
       # @option update_hash [String] password The user's password.
       # @option update_hash [String] password_hash The user's hashed password.
-      # @option update_hash [String] password_hash_type The algorithm originally used to hash the password. 
+      # @option update_hash [String] password_hash_type The algorithm originally used to hash the password.
       #  Valid values are bcrypt.
       sig do
         params(

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -214,34 +214,36 @@ module WorkOS
       # Update a user
       #
       # @param [String] id of the user.
-      # @param [String] first_name The user's first name.
-      # @param [String] last_name The user's last name.
-      # @param [Boolean] email_verified Whether the user's email address was previously verified.
-      # @param [String] password The user's password.
-      # @param [String] password_hash The user's hashed password.
-      # @param [String] last_name The algorithm originally used to hash the password. Valid values are bcrypt.
-   
+      # @param [Hash] update_hash
+      # @option update_hash [String] first_name The user's first name.
+      # @option update_hash [String] last_name The user's last name.
+      # @option update_hash [Boolean] email_verified Whether the user's email address was previously verified.
+      # @option update_hash [String] password The user's password.
+      # @option update_hash [String] password_hash The user's hashed password.
+      # @option update_hash [String] password_hash_type The algorithm originally used to hash the password. Valid values are bcrypt.
       sig do
         params(
           id: String,
-          first_name: T.nilable(String),
-          last_name: T.nilable(String),
-          email_verified: T.nilable(T::Boolean),
-          password: T.nilable(String),
-          password_hash: T.nilable(String),
-          password_hash_type: T.nilable(String),
+          update_hash: {
+            first_name: T.nilable(String), 
+            last_name: T.nilable(String),
+            email_verified: T.nilable(T::Boolean),
+            password: T.nilable(String),
+            password_hash: T.nilable(String),
+            password_hash_type: T.nilable(String)
+          },
         ).returns(WorkOS::User)
       end
-      def update_user(id:, first_name: nil, last_name: nil, email_verified: nil, password: nil, password_hash: nil, password_hash_type: nil)
+      def update_user(id:, update_hash:)
         request = put_request(
           path: "/user_management/users/#{id}",
           body: {
-            first_name: first_name,
-            last_name: last_name,
-            email_verified: email_verified,
-            password: password,
-            password_hash: password_hash,
-            password_hash_type: password_hash_type,
+            first_name: update_hash[:first_name],
+            last_name: update_hash[:last_name],
+            email_verified: update_hash[:email_verified],
+            password: update_hash[:password],
+            password_hash: update_hash[:password_hash],
+            password_hash_type: update_hash[:password_hash_type],
           },
           auth: true,
         )

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -232,7 +232,7 @@ module WorkOS
           email_verified: T.nilable(T::Boolean),
           password: T.nilable(String),
           password_hash: T.nilable(String),
-          password_hash_type: T.nilable(String)
+          password_hash_type: T.nilable(String),
         ).returns(WorkOS::User)
       end
       def update_user(
@@ -261,6 +261,7 @@ module WorkOS
 
         WorkOS::User.new(response.body)
       end
+      # rubocop:enable Metrics/ParameterLists
 
       # Deletes a User
       #

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -220,17 +220,18 @@ module WorkOS
       # @option update_hash [Boolean] email_verified Whether the user's email address was previously verified.
       # @option update_hash [String] password The user's password.
       # @option update_hash [String] password_hash The user's hashed password.
-      # @option update_hash [String] password_hash_type The algorithm originally used to hash the password. Valid values are bcrypt.
+      # @option update_hash [String] password_hash_type The algorithm originally used to hash the password. 
+      #  Valid values are bcrypt.
       sig do
         params(
           id: String,
           update_hash: {
-            first_name: T.nilable(String), 
+            first_name: T.nilable(String),
             last_name: T.nilable(String),
             email_verified: T.nilable(T::Boolean),
             password: T.nilable(String),
             password_hash: T.nilable(String),
-            password_hash_type: T.nilable(String)
+            password_hash_type: T.nilable(String),
           },
         ).returns(WorkOS::User)
       end

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -214,37 +214,45 @@ module WorkOS
       # Update a user
       #
       # @param [String] id of the user.
-      # @param [Hash] update_hash
-      # @option update_hash [String] first_name The user's first name.
-      # @option update_hash [String] last_name The user's last name.
-      # @option update_hash [Boolean] email_verified Whether the user's email address was previously verified.
-      # @option update_hash [String] password The user's password.
-      # @option update_hash [String] password_hash The user's hashed password.
-      # @option update_hash [String] password_hash_type The algorithm originally used to hash the password.
+      # @param [String] first_name The user's first name.
+      # @param [String] last_name The user's last name.
+      # @param [Boolean] email_verified Whether the user's email address was previously verified.
+      # @param [String] password The user's password.
+      # @param [String] password_hash The user's hashed password.
+      # @option [String] password_hash_type The algorithm originally used to hash the password.
       #  Valid values are bcrypt.
+      #
+      # @return [WorkOS::User]
+      # rubocop:disable Metrics/ParameterLists
       sig do
         params(
           id: String,
-          update_hash: {
-            first_name: T.nilable(String),
-            last_name: T.nilable(String),
-            email_verified: T.nilable(T::Boolean),
-            password: T.nilable(String),
-            password_hash: T.nilable(String),
-            password_hash_type: T.nilable(String),
-          },
+          first_name: T.nilable(String),
+          last_name: T.nilable(String),
+          email_verified: T.nilable(T::Boolean),
+          password: T.nilable(String),
+          password_hash: T.nilable(String),
+          password_hash_type: T.nilable(String)
         ).returns(WorkOS::User)
       end
-      def update_user(id:, update_hash:)
+      def update_user(
+        id:,
+        first_name: nil,
+        last_name: nil,
+        email_verified: nil,
+        password: nil,
+        password_hash: nil,
+        password_hash_type: nil,
+      )
         request = put_request(
           path: "/user_management/users/#{id}",
           body: {
-            first_name: update_hash[:first_name],
-            last_name: update_hash[:last_name],
-            email_verified: update_hash[:email_verified],
-            password: update_hash[:password],
-            password_hash: update_hash[:password_hash],
-            password_hash_type: update_hash[:password_hash_type],
+            first_name: first_name,
+            last_name: last_name,
+            email_verified: email_verified,
+            password: password,
+            password_hash: password_hash,
+            password_hash_type: password_hash_type,
           },
           auth: true,
         )

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -217,21 +217,31 @@ module WorkOS
       # @param [String] first_name The user's first name.
       # @param [String] last_name The user's last name.
       # @param [Boolean] email_verified Whether the user's email address was previously verified.
+      # @param [String] password The user's password.
+      # @param [String] password_hash The user's hashed password.
+      # @param [String] last_name The algorithm originally used to hash the password. Valid values are bcrypt.
+   
       sig do
         params(
           id: String,
           first_name: T.nilable(String),
           last_name: T.nilable(String),
           email_verified: T.nilable(T::Boolean),
+          password: T.nilable(String),
+          password_hash: T.nilable(String),
+          password_hash_type: T.nilable(String),
         ).returns(WorkOS::User)
       end
-      def update_user(id:, first_name: nil, last_name: nil, email_verified: nil)
+      def update_user(id:, first_name: nil, last_name: nil, email_verified: nil, password: nil, password_hash: nil, password_hash_type: nil)
         request = put_request(
           path: "/user_management/users/#{id}",
           body: {
             first_name: first_name,
             last_name: last_name,
             email_verified: email_verified,
+            password: password,
+            password_hash: password_hash,
+            password_hash_type: password_hash_type,
           },
           auth: true,
         )

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -242,7 +242,7 @@ module WorkOS
         email_verified: nil,
         password: nil,
         password_hash: nil,
-        password_hash_type: nil,
+        password_hash_type: nil
       )
         request = put_request(
           path: "/user_management/users/#{id}",

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -341,7 +341,7 @@ describe WorkOS::UserManagement do
           VCR.use_cassette 'user_management/update_user/invalid' do
             expect do
               update = {
-                first_name: 'Jane'
+                first_name: 'Jane',
               }
               described_class.update_user(id: 'invalid', update_hash: update)
             end.to raise_error(WorkOS::APIError, /User not found/)

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -324,12 +324,12 @@ describe WorkOS::UserManagement do
     context 'with a valid payload' do
       it 'update_user a user' do
         VCR.use_cassette 'user_management/update_user/valid' do
-          user = described_class.update_user(
-            id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
+          update = {
             first_name: 'Jane',
             last_name: 'Doe',
             email_verified: false,
-          )
+          }
+          user = described_class.update_user(id: 'user_01H7TVSKS45SDHN5V9XPSM6H44', update_hash: update)
           expect(user.first_name).to eq('Jane')
           expect(user.last_name).to eq('Doe')
           expect(user.email_verified).to eq(false)
@@ -340,7 +340,10 @@ describe WorkOS::UserManagement do
         it 'returns an error' do
           VCR.use_cassette 'user_management/update_user/invalid' do
             expect do
-              described_class.update_user(id: 'invalid')
+              update = {
+                first_name: 'Jane'
+              }
+              described_class.update_user(id: 'invalid', update_hash: update)
             end.to raise_error(WorkOS::APIError, /User not found/)
           end
         end

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -324,12 +324,12 @@ describe WorkOS::UserManagement do
     context 'with a valid payload' do
       it 'update_user a user' do
         VCR.use_cassette 'user_management/update_user/valid' do
-          update = {
+          user = described_class.update_user(
+            id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
             first_name: 'Jane',
             last_name: 'Doe',
             email_verified: false,
-          }
-          user = described_class.update_user(id: 'user_01H7TVSKS45SDHN5V9XPSM6H44', update_hash: update)
+          )
           expect(user.first_name).to eq('Jane')
           expect(user.last_name).to eq('Doe')
           expect(user.email_verified).to eq(false)
@@ -340,10 +340,7 @@ describe WorkOS::UserManagement do
         it 'returns an error' do
           VCR.use_cassette 'user_management/update_user/invalid' do
             expect do
-              update = {
-                first_name: 'Jane',
-              }
-              described_class.update_user(id: 'invalid', update_hash: update)
+              described_class.update_user(id: 'invalid')
             end.to raise_error(WorkOS::APIError, /User not found/)
           end
         end


### PR DESCRIPTION
## Description
Add password, password_hash and password_hash_type to UserManagement.update_user function

https://workos.com/docs/reference/user-management/user/update


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
