### PR TITLE
Return AuthenticationReponse instead of UserResponse to surface optional organization_id

### DIFF
--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -45,6 +45,7 @@ module WorkOS
 
   autoload :AuditLogExport, 'workos/audit_log_export'
   autoload :AuthenticationFactorAndChallenge, 'workos/authentication_factor_and_challenge'
+  autoload :AuthenticationResponse, 'workos/authentication_response'
   autoload :AuditLogs, 'workos/audit_logs'
   autoload :Challenge, 'workos/challenge'
   autoload :Client, 'workos/client'

--- a/lib/workos/authentication_response.rb
+++ b/lib/workos/authentication_response.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+# typed: true
+
+module WorkOS
+  # The AuthenticationResponse class represents an Authentication Response as well as an corresponding
+  # response data that can later be appended on.
+  class AuthenticationResponse
+    include HashProvider
+    extend T::Sig
+
+    attr_accessor :user, :organization_id
+
+    sig { params(authentication_response_json: String).void }
+    def initialize(authentication_response_json)
+      json = JSON.parse(authentication_response_json, symbolize_names: true)
+      @user = WorkOS::User.new(json[:user].to_json)
+      @organization_id = T.let(json[:organization_id], T.nilable(String))
+    end
+
+    def to_json(*)
+      {
+        user: user.to_json,
+        organization_id: organization_id,
+      }
+    end
+  end
+end

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -294,7 +294,7 @@ module WorkOS
       # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
       #
-      # @return WorkOS::UserResponse
+      # @return WorkOS::AuthenticationResponse
 
       sig do
         params(
@@ -303,7 +303,7 @@ module WorkOS
           client_id: String,
           ip_address: T.nilable(String),
           user_agent: T.nilable(String),
-        ).returns(WorkOS::UserResponse)
+        ).returns(WorkOS::AuthenticationResponse)
       end
       def authenticate_with_password(email:, password:, client_id:, ip_address: nil, user_agent: nil)
         response = execute_request(
@@ -321,7 +321,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::UserResponse.new(response.body)
+        WorkOS::AuthenticationResponse.new(response.body)
       end
 
       # Authenticate a user using OAuth or an organization's SSO connection.
@@ -332,7 +332,7 @@ module WorkOS
       # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
       #
-      # @return WorkOS::UserResponse
+      # @return WorkOS::AuthenticationResponse
 
       sig do
         params(
@@ -340,7 +340,7 @@ module WorkOS
           client_id: String,
           ip_address: T.nilable(String),
           user_agent: T.nilable(String),
-        ).returns(WorkOS::UserResponse)
+        ).returns(WorkOS::AuthenticationResponse)
       end
       def authenticate_with_code(
         code:,
@@ -362,7 +362,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::UserResponse.new(response.body)
+        WorkOS::AuthenticationResponse.new(response.body)
       end
 
       # Authenticate user by Magic Auth Code.
@@ -375,7 +375,7 @@ module WorkOS
       # after having completed a Magic Code challenge.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
       #
-      # @return WorkOS::UserResponse
+      # @return WorkOS::AuthenticationResponse
 
       sig do
         params(
@@ -385,7 +385,7 @@ module WorkOS
           ip_address: T.nilable(String),
           user_agent: T.nilable(String),
           link_authorization_code: T.nilable(String),
-        ).returns(WorkOS::UserResponse)
+        ).returns(WorkOS::AuthenticationResponse)
       end
       def authenticate_with_magic_auth(
         code:,
@@ -411,7 +411,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::UserResponse.new(response.body)
+        WorkOS::AuthenticationResponse.new(response.body)
       end
 
       # Authenticate a user using TOTP.
@@ -425,7 +425,7 @@ module WorkOS
       # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
       #
-      # @return WorkOS::UserResponse
+      # @return WorkOS::AuthenticationResponse
 
       sig do
         params(
@@ -435,7 +435,7 @@ module WorkOS
           authentication_challenge_id: String,
           ip_address: T.nilable(String),
           user_agent: T.nilable(String),
-        ).returns(WorkOS::UserResponse)
+        ).returns(WorkOS::AuthenticationResponse)
       end
       def authenticate_with_totp(
         code:,
@@ -461,7 +461,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::UserResponse.new(response.body)
+        WorkOS::AuthenticationResponse.new(response.body)
       end
 
       # Authenticate a user using Email Verification Code.
@@ -473,7 +473,7 @@ module WorkOS
       # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
       #
-      # @return WorkOS::UserResponse
+      # @return WorkOS::AuthenticationResponse
 
       sig do
         params(
@@ -482,7 +482,7 @@ module WorkOS
           pending_authentication_token: String,
           ip_address: T.nilable(String),
           user_agent: T.nilable(String),
-        ).returns(WorkOS::UserResponse)
+        ).returns(WorkOS::AuthenticationResponse)
       end
       def authenticate_with_email_verification(
         code:,
@@ -506,7 +506,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::UserResponse.new(response.body)
+        WorkOS::AuthenticationResponse.new(response.body)
       end
 
       # Create a one-time Magic Auth code and emails it to the user.


### PR DESCRIPTION
## Description
Return AuthenticationReponse instead of UserResponse to surface optional organization_id

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
