### PR TITLE
Usermanagement send_magic_auth_code does not return a user anymore

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -557,8 +557,6 @@ module WorkOS
       #
       # @param [String] email The email address the one-time code will be sent to.
       #
-      # @return WorkOS::UserResponse
-      #
       # @return Boolean
       sig do
         params(

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -558,10 +558,12 @@ module WorkOS
       # @param [String] email The email address the one-time code will be sent to.
       #
       # @return WorkOS::UserResponse
+      #
+      # @return Boolean
       sig do
         params(
           email: String,
-        ).returns(WorkOS::UserResponse)
+        ).returns(T::Boolean)
       end
       def send_magic_auth_code(email:)
         response = execute_request(
@@ -574,7 +576,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::UserResponse.new(response.body)
+        response.is_a? Net::HTTPSuccess
       end
 
       # Enroll a user into an authentication factor.

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -571,10 +571,9 @@ describe WorkOS::UserManagement do
     context 'with valid parameters' do
       it 'sends a magic link to the email address' do
         VCR.use_cassette 'user_management/send_magic_auth_code/valid' do
-          magic_link_response = described_class.send_magic_auth_code(
+          described_class.send_magic_auth_code(
             email: 'test@gmail.com',
           )
-          expect(magic_link_response.user.id).to eq('user_01H93WD0R0KWF8Q7BK02C0RPYJ')
         end
       end
     end

--- a/spec/support/fixtures/vcr_cassettes/user_management/send_magic_auth_code/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/send_magic_auth_code/valid.yml
@@ -76,7 +76,7 @@ http_interactions:
           - cloudflare
       body:
         encoding: ASCII-8BIT
-        string: '{"user":{"object":"user","id":"user_01H93WD0R0KWF8Q7BK02C0RPYJ","email":"test@gmail.com","email_verified":true,"first_name":"Adam","last_name":"Zinder","created_at":"2023-08-30T18:48:26.517Z","updated_at":"2023-08-30T18:58:00.821Z","user_type":"unmanaged","email_verified_at":"2023-08-30T18:58:00.915Z","google_oauth_profile_id":null,"microsoft_oauth_profile_id":null}}'
+        string: ""
       http_version:
     recorded_at: Thu, 31 Aug 2023 16:32:01 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description
Usermanagement send_magic_auth_code does not return a user anymore

See api reference documentation, https://workos.com/docs/reference/user-management/magic-auth

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
