### PR TITLE
Add `impersonator` attr to `AuthenticationResponse`

### DIFF
--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -58,6 +58,7 @@ module WorkOS
   autoload :Event, 'workos/event'
   autoload :Events, 'workos/events'
   autoload :Factor, 'workos/factor'
+  autoload :Impersonator, 'workos/impersonator'
   autoload :Invitation, 'workos/invitation'
   autoload :MFA, 'workos/mfa'
   autoload :Organization, 'workos/organization'

--- a/lib/workos/authentication_response.rb
+++ b/lib/workos/authentication_response.rb
@@ -16,11 +16,9 @@ module WorkOS
       @user = WorkOS::User.new(json[:user].to_json)
       @organization_id = T.let(json[:organization_id], T.nilable(String))
       @impersonator =
-        if impersonator_json = json[:impersonator]
+        if (impersonator_json = json[:impersonator])
           Impersonator.new(email: impersonator_json[:email],
-                           reason: impersonator_json[:reason])
-        else
-          nil
+                           reason: impersonator_json[:reason],)
         end
     end
 

--- a/lib/workos/authentication_response.rb
+++ b/lib/workos/authentication_response.rb
@@ -8,19 +8,27 @@ module WorkOS
     include HashProvider
     extend T::Sig
 
-    attr_accessor :user, :organization_id
+    attr_accessor :user, :organization_id, :impersonator
 
     sig { params(authentication_response_json: String).void }
     def initialize(authentication_response_json)
       json = JSON.parse(authentication_response_json, symbolize_names: true)
       @user = WorkOS::User.new(json[:user].to_json)
       @organization_id = T.let(json[:organization_id], T.nilable(String))
+      @impersonator =
+        if impersonator_json = json[:impersonator]
+          Impersonator.new(email: impersonator_json[:email],
+                           reason: impersonator_json[:reason])
+        else
+          nil
+        end
     end
 
     def to_json(*)
       {
         user: user.to_json,
         organization_id: organization_id,
+        impersonator: impersonator.to_json,
       }
     end
   end

--- a/lib/workos/impersonator.rb
+++ b/lib/workos/impersonator.rb
@@ -2,6 +2,8 @@
 # typed: true
 
 module WorkOS
+  # Contains information about a WorkOS Dashboard user impersonating
+  # a User Management user.
   class Impersonator
     include HashProvider
     extend T::Sig

--- a/lib/workos/impersonator.rb
+++ b/lib/workos/impersonator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# typed: true
+
+module WorkOS
+  class Impersonator
+    include HashProvider
+    extend T::Sig
+
+    attr_accessor :email, :reason
+
+    sig { params(email: String, reason: T.nilable(String)).void }
+    def initialize(email:, reason:)
+      @email = email
+      @reason = reason
+    end
+
+    def to_json(*)
+      {
+        email: email,
+        reason: reason,
+      }
+    end
+  end
+end

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -420,6 +420,22 @@ describe WorkOS::UserManagement do
           expect(authentication_response.user.id).to eq('user_01H93ZY4F80YZRRS6N59Z2HFVS')
         end
       end
+
+      context 'when the user is being impersonated' do
+        it 'contains the impersonator metadata' do
+          VCR.use_cassette('user_management/authenticate_with_code/valid_with_impersonator') do
+            authentication_response = WorkOS::UserManagement.authenticate_with_code(
+              code: '01HRX85ATQB2MN40K4FZ9C2HFR',
+              client_id: 'client_01GS91XFB2YPR1C0NR5SH758Q0',
+            )
+
+            expect(authentication_response.impersonator).to have_attributes(
+              email: 'admin@foocorp.com',
+              reason: 'For testing.',
+            )
+          end
+        end
+      end
     end
 
     context 'with an invalid code' do

--- a/spec/support/fixtures/vcr_cassettes/user_management/authenticate_with_code/valid_with_impersonator.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/authenticate_with_code/valid_with_impersonator.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.workos.com/user_management/authenticate
+    body:
+      encoding: UTF-8
+      string: '{"code":"01HRX85ATQB2MN40K4FZ9C2HFR","client_id":"client_01GS91XFB2YPR1C0NR5SH758Q0","client_secret":"<API_KEY>","ip_address":null,"user_agent":null,"grant_type":"authorization_code"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/3.1.1; arm64-darwin21; v4.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 14 Mar 2024 01:10:34 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '875'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 8640628169fa0d54-LAX
+      Cf-Cache-Status:
+      - DYNAMIC
+      Etag:
+      - W/"47c-66YSPNMN47PZx4ahCgTQvmryR90"
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin, Accept-Encoding
+      Via:
+      - 1.1 spaces-router (devel)
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      Expect-Ct:
+      - max-age=0
+      Referrer-Policy:
+      - no-referrer
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - f22ea52f-bf1a-4d5e-acb1-10b2e99ffbe5
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - __cf_bm=pYiV6zsrN3V8vd8vKA_bp0qN2LYd1HUQAIVHcevLYw4-1710378634-1.0.1.1-wNPVRK6jpySHc7bqiAVCtM6T64oKxFAjrcvJNJAPU.RhZFRgPfQRGWYbC4l0ckcsyhZ2_I7GTu17yNowC.smHA;
+        path=/; expires=Thu, 14-Mar-24 01:40:34 GMT; domain=.workos.com; HttpOnly;
+        Secure; SameSite=None
+      - __cfruid=914cc38ede83520e897d1eaef25a8e5daa4975d0-1710378634; path=/; domain=.workos.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"user":{"object":"user","id":"user_01HP0B4ZV2FWWVY0BF16GFDAER","email":"bob@example.com","email_verified":false,"first_name":"Bob","last_name":"Loblaw","profile_picture_url":null,"created_at":"2024-02-06T23:13:18.137Z","updated_at":"2024-02-06T23:13:36.946Z"},"impersonator":{"email":"admin@foocorp.com","reason":"For testing."}}'
+    http_version:
+  recorded_at: Thu, 14 Mar 2024 01:10:34 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description

Adds Impersonation-related fields to the authentication response class.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
