### PR TITLE
v4.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (4.0.0)
+    workos (4.1.0)
       sorbet-runtime (~> 0.5)
 
 GEM

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -2,5 +2,5 @@
 # typed: strong
 
 module WorkOS
-  VERSION = '4.0.0'
+  VERSION = '4.1.0'
 end


### PR DESCRIPTION
## Description

Release version `4.1.0`, which currently includes:

* https://github.com/workos/workos-ruby/pull/269
* https://github.com/workos/workos-ruby/pull/268
* https://github.com/workos/workos-ruby/pull/264

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
