### PR TITLE
Remove "domain" param from list directories query

### DIFF
--- a/lib/workos/directory_sync.rb
+++ b/lib/workos/directory_sync.rb
@@ -15,8 +15,6 @@ module WorkOS
       # Retrieve directories.
       #
       # @param [Hash] options An options hash
-      # @option options [String] domain The domain of the directory to be
-      #  retrieved.
       # @option options [String] search A search term for direcory names.
       # @option options [String] limit Maximum number of records to return.
       # @option options [String] order The order in which to paginate records

--- a/spec/lib/workos/directory_sync_spec.rb
+++ b/spec/lib/workos/directory_sync_spec.rb
@@ -20,29 +20,6 @@ describe WorkOS::DirectorySync do
       end
     end
 
-    context 'with domain option' do
-      it 'forms the proper request to the API' do
-        request_args = [
-          '/directories?domain=foo-corp.com&'\
-          'order=desc',
-          'Content-Type' => 'application/json'
-        ]
-
-        expected_request = Net::HTTP::Get.new(*request_args)
-
-        expect(Net::HTTP::Get).to receive(:new).with(*request_args).
-          and_return(expected_request)
-
-        VCR.use_cassette 'directory_sync/list_directories/with_domain' do
-          directories = described_class.list_directories(
-            domain: 'foo-corp.com',
-          )
-
-          expect(directories.data.size).to eq(1)
-        end
-      end
-    end
-
     context 'with search option' do
       it 'forms the proper request to the API' do
         request_args = [


### PR DESCRIPTION
## Description
We no longer support querying directories by domain, so removing the option from the method doc.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
