### PR TITLE
Fix `revoke_session` by including authorization headers

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -510,14 +510,17 @@ module WorkOS
       # @param [String] session_id The session ID can be found in the `sid`
       #   claim of the access token
       def revoke_session(session_id:)
-        execute_request(
+        response = execute_request(
           request: post_request(
             path: '/user_management/sessions/revoke',
             body: {
               session_id: session_id,
             },
+            auth: true,
           ),
         )
+
+        response.is_a? Net::HTTPSuccess
       end
 
       # Get the JWKS URL

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -1168,7 +1168,7 @@ describe WorkOS::UserManagement do
             )
           end.to raise_error(
             WorkOS::APIError,
-            /Session not found/
+            /Session not found/,
           )
         end
       end

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -1145,4 +1145,33 @@ describe WorkOS::UserManagement do
       end
     end
   end
+
+  describe '.revoke_session' do
+    context 'with valid payload' do
+      it 'revokes session' do
+        VCR.use_cassette 'user_management/revoke_session/valid' do
+          result = described_class.revoke_session(
+            session_id: 'session_01HRX85ATNADY1GQ053AHRFFN6',
+          )
+
+          expect(result).to be true
+        end
+      end
+    end
+
+    context 'with a non-existant session' do
+      it 'returns an error' do
+        VCR.use_cassette 'user_management/revoke_session/not_found' do
+          expect do
+            described_class.revoke_session(
+              session_id: 'session_01H5JQDV7R7ATEYZDEG0W5PRYS',
+            )
+          end.to raise_error(
+            WorkOS::APIError,
+            /Session not found/
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/support/fixtures/vcr_cassettes/user_management/revoke_session/not_found.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/revoke_session/not_found.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.workos.com/user_management/sessions/revoke
+    body:
+      encoding: UTF-8
+      string: '{"session_id":"session_01H5JQDV7R7ATEYZDEG0W5PRYS"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/3.1.4; arm64-darwin22; v4.2.0
+      Authorization:
+      - Bearer <API_KEY>
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 11 Apr 2024 22:36:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 872e74fd9ed6db9e-LAX
+      Cf-Cache-Status:
+      - DYNAMIC
+      Etag:
+      - W/"91-9u3slgvENRDVFp/62vKalhPzVuw"
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      Expect-Ct:
+      - max-age=0
+      Referrer-Policy:
+      - no-referrer
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - bc0771a4-8d66-4b34-809c-d3d8976af390
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - __cf_bm=iJMFbMBT_gDvh2ZbVYwAWHii9wrMPSJJeFQ3sXKSNNw-1712875002-1.0.1.1-d0033NtW0ShwCrgulDZg60Nw0yfEROthaCZQWVIAnWbbmaoa5HDqSkl4DsECxoAaZNdoLWqOxi9YXtZx9FqVSA;
+        path=/; expires=Thu, 11-Apr-24 23:06:42 GMT; domain=.workos.com; HttpOnly;
+        Secure; SameSite=None
+      - __cfruid=c2a61e4869ba7669d8dd1d11a8e59bba189e21ba-1712875002; path=/; domain=.workos.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Session not found: ''session_01H5JQDV7R7ATEYZDEG0W5PRYS''.","code":"entity_not_found","entity_id":"session_01H5JQDV7R7ATEYZDEG0W5PRYS"}'
+    http_version:
+  recorded_at: Thu, 11 Apr 2024 22:36:42 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/fixtures/vcr_cassettes/user_management/revoke_session/valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/revoke_session/valid.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.workos.com/user_management/sessions/revoke
+    body:
+      encoding: UTF-8
+      string: '{"session_id":"session_01HRX85ATNADY1GQ053AHRFFN6"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/3.1.4; arm64-darwin22; v4.2.0
+      Authorization:
+      - Bearer <API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 11 Apr 2024 22:36:42 GMT
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 872e74fc2ee3092d-LAX
+      Cf-Cache-Status:
+      - DYNAMIC
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      Expect-Ct:
+      - max-age=0
+      Referrer-Policy:
+      - no-referrer
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 1b04e560-4438-40ba-97d2-05ae571aeedf
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - __cf_bm=lXssAzjuk1ajbWnDLtD_SUYIufESNBd9WVxCY8MCxJU-1712875002-1.0.1.1-oBbEhifco.kAMIrc30VrsrzW8tP4OpouniBD3jTd.5UowyS_IWs6ah59yKeFO9X6IqMLjlJt6n5O9lTpN0.2fw;
+        path=/; expires=Thu, 11-Apr-24 23:06:42 GMT; domain=.workos.com; HttpOnly;
+        Secure; SameSite=None
+      - __cfruid=c2a61e4869ba7669d8dd1d11a8e59bba189e21ba-1712875002; path=/; domain=.workos.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version:
+  recorded_at: Thu, 11 Apr 2024 22:36:42 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description

We should have been passing `auth: true` in order authorization headers to be included in the request. Since this method was already broken and would have never returned successfully, I also updated it to return a boolean like our other methods which where the API doesn't have a meaningful response payload.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
