### PR TITLE
`v4.4.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (4.3.0)
+    workos (4.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WorkOS
-  VERSION = '4.3.0'
+  VERSION = '4.4.0'
 end


### PR DESCRIPTION
## Description

Bumps the Gem version to `v4.4.0`, releasing the following changes:

* #291 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
