### PR TITLE
v4.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (4.4.0)
+    workos (4.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WorkOS
-  VERSION = '4.4.0'
+  VERSION = '4.5.0'
 end


### PR DESCRIPTION
## Description
Adds API changes to support sending your own emails for invitations and Magic Auth.

- Adds `accept_invitation_url` to invitation object returned by API
- Adds new endpoints for the Magic Auth API: `get_magic_auth` and `create_magic_auth`
- Deprecates current `send_magic_auth_code` method in favor of `create_magic_auth`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
