### PR TITLE
Add new error types and add data to error response

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,4 +68,4 @@ DEPENDENCIES
   workos!
 
 BUNDLED WITH
-   2.2.33
+   2.5.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,4 +68,4 @@ DEPENDENCIES
   workos!
 
 BUNDLED WITH
-   2.5.10
+   2.2.33

--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -87,4 +87,7 @@ module WorkOS
   autoload :InvalidRequestError, 'workos/errors'
   autoload :SignatureVerificationError, 'workos/errors'
   autoload :TimeoutError, 'workos/errors'
+  autoload :NotFoundError, 'workos/errors'
+  autoload :UnprocessableEntityError, 'workos/errors'
+  autoload :RateLimitExceededError, 'workos/errors'
 end

--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -86,7 +86,7 @@ module WorkOS
       ].join('; ')
     end
 
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity:
     def handle_error_response(response:)
       http_status = response.code.to_i
       json = JSON.parse(response.body)
@@ -142,7 +142,7 @@ module WorkOS
         )
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity:
 
     private
 

--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -125,6 +125,8 @@ module WorkOS
           message: message,
           http_status: http_status,
           request_id: response['x-request-id'],
+          error: json['error'],
+          errors: errors,
           code: code,
         )
       when 429

--- a/lib/workos/errors.rb
+++ b/lib/workos/errors.rb
@@ -7,6 +7,10 @@ module WorkOS
     attr_reader :request_id
     attr_reader :code
     attr_reader :errors
+    attr_reader :error
+    attr_reader :error_description
+    attr_reader :data
+    attr_reader :retry_after
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(
@@ -16,7 +20,9 @@ module WorkOS
       http_status: nil,
       request_id: nil,
       code: nil,
-      errors: nil
+      errors: nil,
+      data: nil,
+      retry_after: nil
     )
       @message = message
       @error = error
@@ -25,6 +31,8 @@ module WorkOS
       @request_id = request_id
       @code = code
       @errors = errors
+      @data = data
+      @retry_after = retry_after
     end
     # rubocop:enable Metrics/ParameterLists
 
@@ -62,4 +70,13 @@ module WorkOS
 
   # TimeoutError is raised when the HTTP request to the API times out
   class TimeoutError < WorkOSError; end
+
+  # RateLimitExceededError is raised when the rate limit for the API has been hit
+  class RateLimitExceededError < WorkOSError; end
+
+  # NotFoundError is raised when a resource is not found
+  class NotFoundError < WorkOSError; end
+
+  # UnprocessableEntityError is raised when a request is made that cannot be processed
+  class UnprocessableEntityError < WorkOSError; end
 end

--- a/spec/lib/workos/client.rb
+++ b/spec/lib/workos/client.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+describe WorkOS::Client do
+  describe '.client' do
+    it 'returns a 400 error with appropriate fields' do
+      VCR.use_cassette('user_management/authenticate_with_code/invalid') do
+        expect do
+          WorkOS::UserManagement.authenticate_with_code(
+            code: 'invalid',
+            client_id: 'client_123',
+            ip_address: '200.240.210.16',
+            user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36',
+          )
+        end.to raise_error do |error|
+          expect(error).to be_a(WorkOS::InvalidRequestError)
+          expect(error.error).not_to be_nil
+          expect(error.error_description).not_to be_nil
+          expect(error.data).not_to be_nil
+        end
+      end
+    end
+
+    it 'returns a 401 error with appropriate fields' do
+      VCR.use_cassette('base/execute_request_unauthenticated') do
+        expect do
+          WorkOS::AuditLogs.create_event(
+            organization: 'org_123',
+            event: {},
+          )
+        end.to raise_error do |error|
+          expect(error).to be_a(WorkOS::AuthenticationError)
+          expect(error.message).not_to be_nil
+        end
+      end
+    end
+
+    it 'returns a 404 error with appropriate fields' do
+      VCR.use_cassette('user_management/get_email_verification/invalid') do
+        expect do
+          WorkOS::UserManagement.get_email_verification(
+            id: 'invalid',
+          )
+        end.to raise_error do |error|
+          expect(error).to be_a(WorkOS::NotFoundError)
+          expect(error.message).not_to be_nil
+        end
+      end
+    end
+
+    it 'returns a 422 error with appropriate fields' do
+      VCR.use_cassette('user_management/create_user_invalid') do
+        expect do
+          WorkOS::UserManagement.create_user(
+            email: 'invalid',
+          )
+        end.to raise_error do |error|
+          expect(error).to be_a(WorkOS::UnprocessableEntityError)
+          expect(error.message).not_to be_nil
+          expect(error.errors).not_to be_nil
+          expect(error.code).not_to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/workos/client.rb
+++ b/spec/lib/workos/client.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/MultilineBlockChain
 describe WorkOS::Client do
   describe '.client' do
     it 'returns a 400 error with appropriate fields' do
@@ -63,3 +64,4 @@ describe WorkOS::Client do
     end
   end
 end
+# rubocop:enable Style/MultilineBlockChain

--- a/spec/lib/workos/directory_sync_spec.rb
+++ b/spec/lib/workos/directory_sync_spec.rb
@@ -171,7 +171,7 @@ describe WorkOS::DirectorySync do
           expect do
             WorkOS::DirectorySync.get_directory(id: 'invalid')
           end.to raise_error(
-            WorkOS::APIError,
+            WorkOS::NotFoundError,
             "Status 404, Directory not found: 'invalid'. - request ID: ",
           )
         end
@@ -185,7 +185,7 @@ describe WorkOS::DirectorySync do
         VCR.use_cassette('directory_sync/list_groups/with_no_options') do
           expect do
             WorkOS::DirectorySync.list_groups
-          end.to raise_error(WorkOS::InvalidRequestError)
+          end.to raise_error(WorkOS::UnprocessableEntityError)
         end
       end
     end
@@ -319,7 +319,7 @@ describe WorkOS::DirectorySync do
         VCR.use_cassette('directory_sync/list_users/with_no_options') do
           expect do
             WorkOS::DirectorySync.list_users
-          end.to raise_error(WorkOS::InvalidRequestError)
+          end.to raise_error(WorkOS::UnprocessableEntityError)
         end
       end
     end
@@ -471,7 +471,7 @@ describe WorkOS::DirectorySync do
         VCR.use_cassette('directory_sync/get_group_with_invalid_id') do
           expect do
             WorkOS::DirectorySync.get_group('invalid')
-          end.to raise_error(WorkOS::APIError)
+          end.to raise_error(WorkOS:: NotFoundError)
         end
       end
     end
@@ -498,7 +498,7 @@ describe WorkOS::DirectorySync do
         VCR.use_cassette('directory_sync/get_user_with_invalid_id') do
           expect do
             WorkOS::DirectorySync.get_user('invalid')
-          end.to raise_error(WorkOS::APIError)
+          end.to raise_error(WorkOS::NotFoundError)
         end
       end
     end

--- a/spec/lib/workos/mfa_spec.rb
+++ b/spec/lib/workos/mfa_spec.rb
@@ -188,7 +188,7 @@ describe WorkOS::MFA do
                 authentication_challenge_id: 'auth_challenge_01FZ4YVRBMXP5ZM0A7BP4AJ12J',
                 code: '897792',
               )
-            end.to raise_error(WorkOS::InvalidRequestError)
+            end.to raise_error(WorkOS::UnprocessableEntityError)
           end
         end
       end
@@ -201,7 +201,7 @@ describe WorkOS::MFA do
                 authentication_challenge_id: 'auth_challenge_01FZ4YVRBMXP5ZM0A7BP4AJ12J',
                 code: '897792',
               )
-            end.to raise_error(WorkOS::InvalidRequestError)
+            end.to raise_error(WorkOS::UnprocessableEntityError)
           end
         end
       end
@@ -264,7 +264,7 @@ describe WorkOS::MFA do
             described_class.get_factor(
               id: 'auth_factor_invalid',
             )
-          end.to raise_error(WorkOS::APIError)
+          end.to raise_error(WorkOS::NotFoundError)
         end
       end
     end

--- a/spec/lib/workos/organizations_spec.rb
+++ b/spec/lib/workos/organizations_spec.rb
@@ -257,7 +257,7 @@ describe WorkOS::Organizations do
           expect do
             described_class.get_organization(id: 'invalid')
           end.to raise_error(
-            WorkOS::APIError,
+            WorkOS::NotFoundError,
             'Status 404, Not Found - request ID: ',
           )
         end
@@ -302,7 +302,7 @@ describe WorkOS::Organizations do
           expect do
             described_class.delete_organization(id: 'invalid')
           end.to raise_error(
-            WorkOS::APIError,
+            WorkOS::NotFoundError,
             'Status 404, Not Found - request ID: ',
           )
         end

--- a/spec/lib/workos/passwordless_spec.rb
+++ b/spec/lib/workos/passwordless_spec.rb
@@ -32,7 +32,7 @@ describe WorkOS::Passwordless do
           expect do
             described_class.create_session(invalid_options)
           end.to raise_error(
-            WorkOS::InvalidRequestError,
+            WorkOS::UnprocessableEntityError,
             /Status 422, Validation failed \(email: email must be a string; type: type must be a valid enum value\)/,
           )
         end
@@ -66,7 +66,7 @@ describe WorkOS::Passwordless do
           expect do
             described_class.send_session('session_123')
           end.to raise_error(
-            WorkOS::InvalidRequestError,
+            WorkOS::UnprocessableEntityError,
             /Status 422, The passwordless session 'session_123' has expired or is invalid./,
           )
         end

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -618,7 +618,7 @@ describe WorkOS::SSO do
           expect do
             WorkOS::SSO.get_connection(id: 'invalid')
           end.to raise_error(
-            WorkOS::APIError,
+            WorkOS::NotFoundError,
             'Status 404, Not Found - request ID: ',
           )
         end
@@ -645,7 +645,7 @@ describe WorkOS::SSO do
           expect do
             WorkOS::SSO.delete_connection(id: 'invalid')
           end.to raise_error(
-            WorkOS::APIError,
+            WorkOS::NotFoundError,
             'Status 404, Not Found - request ID: ',
           )
         end

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -312,7 +312,7 @@ describe WorkOS::UserManagement do
             expect do
               described_class.create_user(email: '')
             end.to raise_error(
-              WorkOS::InvalidRequestError,
+              WorkOS::UnprocessableEntityError,
               /email_string_required/,
             )
           end
@@ -342,7 +342,7 @@ describe WorkOS::UserManagement do
           VCR.use_cassette 'user_management/update_user/invalid' do
             expect do
               described_class.update_user(id: 'invalid')
-            end.to raise_error(WorkOS::APIError, /User not found/)
+            end.to raise_error(WorkOS::NotFoundError, /User not found/)
           end
         end
       end
@@ -367,7 +367,7 @@ describe WorkOS::UserManagement do
         VCR.use_cassette('user_management/delete_user/invalid') do
           expect do
             WorkOS::UserManagement.delete_user(id: 'invalid')
-          end.to raise_error(WorkOS::APIError, /User not found/)
+          end.to raise_error(WorkOS::NotFoundError, /User not found/)
         end
       end
     end
@@ -400,7 +400,7 @@ describe WorkOS::UserManagement do
               ip_address: '200.240.210.16',
               user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/108.0.0.0 Safari/537.36',
             )
-          end.to raise_error(WorkOS::APIError, /User not found/)
+          end.to raise_error(WorkOS::NotFoundError, /User not found/)
         end
       end
     end
@@ -512,7 +512,7 @@ describe WorkOS::UserManagement do
               client_id: 'client_123',
               email: 'test@workos.com',
             )
-          end.to raise_error(WorkOS::APIError, /User not found/)
+          end.to raise_error(WorkOS::NotFoundError, /User not found/)
         end
       end
     end
@@ -637,7 +637,7 @@ describe WorkOS::UserManagement do
         VCR.use_cassette('user_management/get_magic_auth/invalid') do
           expect do
             WorkOS::UserManagement.get_magic_auth(id: 'invalid')
-          end.to raise_error(WorkOS::APIError, /MagicAuth not found/)
+          end.to raise_error(WorkOS::NotFoundError, /MagicAuth not found/)
         end
       end
     end
@@ -756,7 +756,7 @@ describe WorkOS::UserManagement do
         VCR.use_cassette('user_management/get_email_verification/invalid') do
           expect do
             WorkOS::UserManagement.get_email_verification(id: 'invalid')
-          end.to raise_error(WorkOS::APIError, /Email Verification not found/)
+          end.to raise_error(WorkOS::NotFoundError, /Email Verification not found/)
         end
       end
     end
@@ -781,7 +781,7 @@ describe WorkOS::UserManagement do
             described_class.send_verification_email(
               user_id: 'bad_id',
             )
-          end.to raise_error(WorkOS::APIError, /User not found/)
+          end.to raise_error(WorkOS::NotFoundError, /User not found/)
         end
       end
     end
@@ -810,7 +810,7 @@ describe WorkOS::UserManagement do
                 code: '659770',
                 user_id: 'bad_id',
               )
-            end.to raise_error(WorkOS::APIError, /User not found/)
+            end.to raise_error(WorkOS::NotFoundError, /User not found/)
           end
         end
       end
@@ -849,7 +849,7 @@ describe WorkOS::UserManagement do
         VCR.use_cassette('user_management/get_password_reset/invalid') do
           expect do
             WorkOS::UserManagement.get_password_reset(id: 'invalid')
-          end.to raise_error(WorkOS::APIError, /Password Reset not found/)
+          end.to raise_error(WorkOS::NotFoundError, /Password Reset not found/)
         end
       end
     end
@@ -893,7 +893,7 @@ describe WorkOS::UserManagement do
               password_reset_url: '',
             )
           end.to raise_error(
-            WorkOS::InvalidRequestError,
+            WorkOS::UnprocessableEntityError,
             /password_reset_url_string_required/,
           )
         end
@@ -924,7 +924,7 @@ describe WorkOS::UserManagement do
               new_password: 'new_password',
             )
           end.to raise_error(
-            WorkOS::APIError,
+            WorkOS::NotFoundError,
             /Could not locate user with provided token/,
           )
         end
@@ -1048,7 +1048,7 @@ describe WorkOS::UserManagement do
             expect do
               described_class.create_organization_membership(user_id: '', organization_id: '')
             end.to raise_error(
-              WorkOS::InvalidRequestError,
+              WorkOS::UnprocessableEntityError,
               /user_id_string_required/,
             )
           end
@@ -1075,7 +1075,7 @@ describe WorkOS::UserManagement do
         VCR.use_cassette('user_management/delete_organization_membership/invalid') do
           expect do
             WorkOS::UserManagement.delete_organization_membership(id: 'invalid')
-          end.to raise_error(WorkOS::APIError, /Organization Membership not found/)
+          end.to raise_error(WorkOS::NotFoundError, /Organization Membership not found/)
         end
       end
     end
@@ -1150,7 +1150,7 @@ describe WorkOS::UserManagement do
         VCR.use_cassette('user_management/get_invitation/invalid') do
           expect do
             WorkOS::UserManagement.get_invitation(id: 'invalid')
-          end.to raise_error(WorkOS::APIError, /Invitation not found/)
+          end.to raise_error(WorkOS::NotFoundError, /Invitation not found/)
         end
       end
     end
@@ -1175,7 +1175,7 @@ describe WorkOS::UserManagement do
         VCR.use_cassette('user_management/find_invitation_by_token/invalid') do
           expect do
             WorkOS::UserManagement.find_invitation_by_token(token: 'invalid')
-          end.to raise_error(WorkOS::APIError, /Invitation not found/)
+          end.to raise_error(WorkOS::NotFoundError, /Invitation not found/)
         end
       end
     end
@@ -1346,7 +1346,7 @@ describe WorkOS::UserManagement do
               id: 'invalid_id',
             )
           end.to raise_error(
-            WorkOS::APIError,
+            WorkOS::NotFoundError,
             /Invitation not found/,
           )
         end
@@ -1375,7 +1375,7 @@ describe WorkOS::UserManagement do
               session_id: 'session_01H5JQDV7R7ATEYZDEG0W5PRYS',
             )
           end.to raise_error(
-            WorkOS::APIError,
+            WorkOS::NotFoundError,
             /Session not found/,
           )
         end

--- a/spec/support/fixtures/vcr_cassettes/base/execute_request_unauthenticated.yml
+++ b/spec/support/fixtures/vcr_cassettes/base/execute_request_unauthenticated.yml
@@ -1,66 +1,66 @@
 ---
 http_interactions:
-- request:
-    method: post
-    uri: https://api.workos.com/events
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - WorkOS; ruby/2.6.5; x86_64-darwin19; v0.1.0
-      Authorization:
-      - 'Bearer '
-  response:
-    status:
-      code: 401
-      message: Unauthorized
-    headers:
-      Server:
-      - Cowboy
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Origin:
-      - https://dashboard.workos-test.com
-      Vary:
-      - Origin, Accept-Encoding
-      Access-Control-Allow-Credentials:
-      - 'true'
-      X-Dns-Prefetch-Control:
-      - 'off'
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=15552000; includeSubDomains
-      X-Download-Options:
-      - noopen
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Request-Id:
-      - 32a67a24-bfaf-4463-bf47-c407d54955d3
-      Request-Id:
-      - 32a67a24-bfaf-4463-bf47-c407d54955d3
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '26'
-      Etag:
-      - W/"1a-pljHtlo127JYJR4E/RYOPb6ucbw"
-      Date:
-      - Sat, 11 Jan 2020 03:50:27 GMT
-      Via:
-      - 1.1 vegur
-    body:
-      encoding: UTF-8
-      string: '{"message":"Unauthorized"}'
-    http_version: 
-  recorded_at: Sat, 11 Jan 2020 03:50:27 GMT
+  - request:
+      method: post
+      uri: https://api.workos.com/audit_logs/events
+      body:
+        encoding: UTF-8
+        string: '{}'
+      headers:
+        Content-Type:
+          - application/json
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - '*/*'
+        User-Agent:
+          - WorkOS; ruby/2.6.5; x86_64-darwin19; v0.1.0
+        Authorization:
+          - 'Bearer '
+    response:
+      status:
+        code: 401
+        message: Unauthorized
+      headers:
+        Server:
+          - Cowboy
+        Connection:
+          - keep-alive
+        Access-Control-Allow-Origin:
+          - https://dashboard.workos-test.com
+        Vary:
+          - Origin, Accept-Encoding
+        Access-Control-Allow-Credentials:
+          - 'true'
+        X-Dns-Prefetch-Control:
+          - 'off'
+        X-Frame-Options:
+          - SAMEORIGIN
+        Strict-Transport-Security:
+          - max-age=15552000; includeSubDomains
+        X-Download-Options:
+          - noopen
+        X-Content-Type-Options:
+          - nosniff
+        X-Xss-Protection:
+          - 1; mode=block
+        X-Request-Id:
+          - 32a67a24-bfaf-4463-bf47-c407d54955d3
+        Request-Id:
+          - 32a67a24-bfaf-4463-bf47-c407d54955d3
+        Content-Type:
+          - application/json; charset=utf-8
+        Content-Length:
+          - '26'
+        Etag:
+          - W/"1a-pljHtlo127JYJR4E/RYOPb6ucbw"
+        Date:
+          - Sat, 11 Jan 2020 03:50:27 GMT
+        Via:
+          - 1.1 vegur
+      body:
+        encoding: UTF-8
+        string: '{"message":"Unauthorized"}'
+      http_version:
+    recorded_at: Sat, 11 Jan 2020 03:50:27 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description

- Adds new error types to be more specific
- Adds data to 400 error responses so users can find out exactly what went wrong

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
