### PR TITLE
Add AppleOAuth constants

### DIFF
--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -28,8 +28,8 @@ module WorkOS
       #  connection, or organization is required.
       #  The domain is deprecated.
       # @param [String] provider A provider name for an Identity Provider
-      #  configured on your WorkOS dashboard. Only 'GoogleOAuth' and
-      #  'MicrosoftOAuth' are supported.
+      #  configured on your WorkOS dashboard. Only 'GoogleOAuth',
+      #  'MicrosoftOAuth', 'GithubOAuth', and 'AppleOAuth' are supported.
       # @param [String] connection The ID for a Connection configured on
       #  WorkOS.
       # @param [String] organization The ID for an Organization configured

--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -28,7 +28,7 @@ module WorkOS
       #  connection, or organization is required.
       #  The domain is deprecated.
       # @param [String] provider A provider name for an Identity Provider
-      #  configured on your WorkOS dashboard. Only 'AppleOAuth', 'GithubOAuth',
+      #  configured on your WorkOS dashboard. Only 'AppleOAuth', 'GitHubOAuth',
       # 'GoogleOAuth', and 'MicrosoftOAuth' are supported.
       # @param [String] connection The ID for a Connection configured on
       #  WorkOS.

--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -28,8 +28,8 @@ module WorkOS
       #  connection, or organization is required.
       #  The domain is deprecated.
       # @param [String] provider A provider name for an Identity Provider
-      #  configured on your WorkOS dashboard. Only 'GoogleOAuth',
-      #  'MicrosoftOAuth', 'GithubOAuth', and 'AppleOAuth' are supported.
+      #  configured on your WorkOS dashboard. Only 'AppleOAuth', 'GithubOAuth',
+      # 'GoogleOAuth', and 'MicrosoftOAuth' are supported.
       # @param [String] connection The ID for a Connection configured on
       #  WorkOS.
       # @param [String] organization The ID for an Organization configured

--- a/lib/workos/types/provider.rb
+++ b/lib/workos/types/provider.rb
@@ -5,6 +5,7 @@ module WorkOS
     # The Provider constants are declarations of a
     # fixed set of values for SSO Providers.
     module Provider
+      Apple = 'AppleOAuth'
       GitHub = 'GitHubOAuth'
       Google = 'GoogleOAuth'
       Microsoft = 'MicrosoftOAuth'

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -45,8 +45,8 @@ module WorkOS
       #  configured redirect URI on your WorkOS dashboard.
       # @param [String] client_id This value can be obtained from the API Keys page in the WorkOS dashboard.
       # @param [String] provider A provider name is used to initiate SSO using an
-      # OAuth-compatible provider. Only 'authkit' ,'GoogleOAuth', 'MicrosoftOAuth',
-      # 'GithubOAuth', and 'AppleOAuth' are supported.
+      # OAuth-compatible provider. Only 'authkit', 'AppleOAuth', 'GithubOAuth', 'GoogleOAuth',
+      # and 'MicrosoftOAuth' are supported.
       # @param [String] connection_id The ID for a Connection configured on
       #  WorkOS.
       # @param [String] organization_id The organization_id selector is used to

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -13,6 +13,7 @@ module WorkOS
       # The ProviderEnum is a declaration of a
       # fixed set of values for User Management Providers.
       class Provider
+        Apple = 'AppleOAuth'
         GitHub = 'GitHubOAuth'
         Google = 'GoogleOAuth'
         Microsoft = 'MicrosoftOAuth'
@@ -44,7 +45,8 @@ module WorkOS
       #  configured redirect URI on your WorkOS dashboard.
       # @param [String] client_id This value can be obtained from the API Keys page in the WorkOS dashboard.
       # @param [String] provider A provider name is used to initiate SSO using an
-      # OAuth-compatible provider. Only 'authkit ,'GoogleOAuth' and 'MicrosoftOAuth' are supported.
+      # OAuth-compatible provider. Only 'authkit' ,'GoogleOAuth', 'MicrosoftOAuth',
+      # 'GithubOAuth', and 'AppleOAuth' are supported.
       # @param [String] connection_id The ID for a Connection configured on
       #  WorkOS.
       # @param [String] organization_id The organization_id selector is used to

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -45,7 +45,7 @@ module WorkOS
       #  configured redirect URI on your WorkOS dashboard.
       # @param [String] client_id This value can be obtained from the API Keys page in the WorkOS dashboard.
       # @param [String] provider A provider name is used to initiate SSO using an
-      # OAuth-compatible provider. Only 'authkit', 'AppleOAuth', 'GithubOAuth', 'GoogleOAuth',
+      # OAuth-compatible provider. Only 'authkit', 'AppleOAuth', 'GitHubOAuth', 'GoogleOAuth',
       # and 'MicrosoftOAuth' are supported.
       # @param [String] connection_id The ID for a Connection configured on
       #  WorkOS.


### PR DESCRIPTION
## Description
Add the `AppleOAuth` constant so SDK users can kick off login flows with Sign in with Apple.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
