### PR TITLE
Add `organization_id` parameter to `authenticate_with_refresh_token`

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -318,6 +318,7 @@ module WorkOS
       #
       # @param [String] refresh_token The refresh token previously obtained from a successful authentication call
       # @param [String] client_id The WorkOS client ID for the environment
+      # @param [String] organization_id The organization to issue the new access token for. (Optional)
       # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
       #
@@ -325,6 +326,7 @@ module WorkOS
       def authenticate_with_refresh_token(
         refresh_token:,
         client_id:,
+        organization_id: nil,
         ip_address: nil,
         user_agent: nil
       )
@@ -338,6 +340,7 @@ module WorkOS
               ip_address: ip_address,
               user_agent: user_agent,
               grant_type: 'refresh_token',
+              organization_id: organization_id,
             },
           ),
         )


### PR DESCRIPTION
## Description

Adds support for the optional `organization_id` parameter for use with the `refresh_token` grant type.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
