### PR TITLE
Bump version to v5.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (5.5.1)
+    workos (5.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WorkOS
-  VERSION = '5.5.1'
+  VERSION = '5.6.0'
 end


### PR DESCRIPTION
## Description
Adds:
- https://github.com/workos/workos-ruby/pull/326
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
