### PR TITLE
Add `return_to` param to `UserManagement.get_logout_url`

### DIFF
--- a/lib/workos/session.rb
+++ b/lib/workos/session.rb
@@ -101,18 +101,17 @@ module WorkOS
     # rubocop:enable Metrics/PerceivedComplexity
 
     # Returns a URL to redirect the user to for logging out
+    # @param return_to [String] The URL to redirect the user to after logging out
     # @return [String] The URL to redirect the user to for logging out
-    # rubocop:disable Naming/AccessorMethodName
-    def get_logout_url
+    def get_logout_url(return_to: nil)
       auth_response = authenticate
 
       unless auth_response[:authenticated]
         raise "Failed to extract session ID for logout URL: #{auth_response[:reason]}"
       end
 
-      @user_management.get_logout_url(session_id: auth_response[:session_id])
+      @user_management.get_logout_url(session_id: auth_response[:session_id], return_to: return_to)
     end
-    # rubocop:enable Naming/AccessorMethodName
 
     # Encrypts and seals data using AES-256-GCM
     # @param data [Hash] The data to seal

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -530,13 +530,17 @@ module WorkOS
       #
       # @param [String] session_id The session ID can be found in the `sid`
       #   claim of the access token
+      # @param [String] return_to The URL to redirect the user to after logging out
       #
       # @return String
-      def get_logout_url(session_id:)
+      def get_logout_url(session_id:, return_to: nil)
+        params = { session_id: session_id }
+        params[:return_to] = return_to if return_to
+
         URI::HTTPS.build(
           host: WorkOS.config.api_hostname,
           path: '/user_management/sessions/logout',
-          query: "session_id=#{session_id}",
+          query: URI.encode_www_form(params),
         ).to_s
       end
 

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -1450,5 +1450,16 @@ describe WorkOS::UserManagement do
 
       expect(result).to eq 'https://api.workos.com/user_management/sessions/logout?session_id=session_01HRX85ATNADY1GQ053AHRFFN6'
     end
+
+    context 'when a `return_to` is given' do
+      it 'returns a logout url with the `return_to` query parameter' do
+        result = described_class.get_logout_url(
+          session_id: 'session_01HRX85ATNADY1GQ053AHRFFN6',
+          return_to: 'https://example.com/signed-out',
+        )
+
+        expect(result).to eq 'https://api.workos.com/user_management/sessions/logout?session_id=session_01HRX85ATNADY1GQ053AHRFFN6&return_to=https%3A%2F%2Fexample.com%2Fsigned-out'
+      end
+    end
   end
 end

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -1441,4 +1441,14 @@ describe WorkOS::UserManagement do
       end
     end
   end
+
+  describe '.get_logout_url' do
+    it 'returns a logout url for the given session ID' do
+      result = described_class.get_logout_url(
+        session_id: 'session_01HRX85ATNADY1GQ053AHRFFN6',
+      )
+
+      expect(result).to eq 'https://api.workos.com/user_management/sessions/logout?session_id=session_01HRX85ATNADY1GQ053AHRFFN6'
+    end
+  end
 end


### PR DESCRIPTION
## Description

Adds a new optional `return_to` parameter to `UserManagement.get_logout_url` to support the upcoming Logout URIs feature.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
