### PR TITLE
Add domain verification intent in admin portal link generation

### DIFF
--- a/lib/workos/types/intent.rb
+++ b/lib/workos/types/intent.rb
@@ -10,8 +10,9 @@ module WorkOS
       DSYNC = 'dsync'
       LOG_STREAMS = 'log_streams'
       SSO = 'sso'
+      DOMAIN_VERIFICATION = 'domain_verification'
 
-      ALL = [AUDIT_LOGS, CERTIFICATE_RENEWAL, DSYNC, LOG_STREAMS, SSO].freeze
+      ALL = [AUDIT_LOGS, CERTIFICATE_RENEWAL, DSYNC, LOG_STREAMS, SSO, DOMAIN_VERIFICATION].freeze
     end
   end
 end

--- a/lib/workos/types/intent.rb
+++ b/lib/workos/types/intent.rb
@@ -7,12 +7,12 @@ module WorkOS
     module Intent
       AUDIT_LOGS = 'audit_logs'
       CERTIFICATE_RENEWAL = 'certificate_renewal'
+      DOMAIN_VERIFICATION = 'domain_verification'
       DSYNC = 'dsync'
       LOG_STREAMS = 'log_streams'
       SSO = 'sso'
-      DOMAIN_VERIFICATION = 'domain_verification'
 
-      ALL = [AUDIT_LOGS, CERTIFICATE_RENEWAL, DSYNC, LOG_STREAMS, SSO, DOMAIN_VERIFICATION].freeze
+      ALL = [AUDIT_LOGS, CERTIFICATE_RENEWAL, DOMAIN_VERIFICATION, DSYNC, LOG_STREAMS, SSO].freeze
     end
   end
 end

--- a/spec/lib/workos/portal_spec.rb
+++ b/spec/lib/workos/portal_spec.rb
@@ -81,6 +81,7 @@ describe WorkOS::Portal do
           )
         end
       end
+    end  
 
     describe 'with an invalid organization' do
       it 'raises an error' do

--- a/spec/lib/workos/portal_spec.rb
+++ b/spec/lib/workos/portal_spec.rb
@@ -81,7 +81,7 @@ describe WorkOS::Portal do
           )
         end
       end
-    end  
+    end
 
     describe 'with an invalid organization' do
       it 'raises an error' do

--- a/spec/lib/workos/portal_spec.rb
+++ b/spec/lib/workos/portal_spec.rb
@@ -68,6 +68,20 @@ describe WorkOS::Portal do
       end
     end
 
+    describe 'with the domain_verification intent' do
+      it 'returns an Admin Portal link' do
+        VCR.use_cassette 'portal/generate_link_domain_verification', match_requests_on: %i[path body] do
+          portal_link = described_class.generate_link(
+            intent: 'domain_verification',
+            organization: organization,
+          )
+
+          expect(portal_link).to eq(
+            'https://id.workos.com/portal/launch?secret=secret',
+          )
+        end
+      end
+
     describe 'with an invalid organization' do
       it 'raises an error' do
         VCR.use_cassette 'portal/generate_link_invalid' do

--- a/spec/support/fixtures/vcr_cassettes/portal/generate_link_domain_verification.yml
+++ b/spec/support/fixtures/vcr_cassettes/portal/generate_link_domain_verification.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.workos.com/portal/generate_link
+    body:
+      encoding: UTF-8
+      string: '{"intent":"domain_verification","organization":"org_01EHQMYV6MBK39QC5PZXHY59C3","return_url":null,"success_url":null}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - WorkOS; ruby/2.7.1; x86_64-darwin19; v0.5.0
+      Authorization:
+      - Bearer <API_KEY>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      X-Dns-Prefetch-Control:
+      - 'off'
+      Expect-Ct:
+      - max-age=0
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - cb9ad5cf-243a-4084-a4f6-2d7d2b097b8b
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '79'
+      Etag:
+      - W/"4f-NN86NUZRu/GQgPAYTexTS6/9DnM"
+      Date:
+      - Wed, 09 Sep 2020 23:43:07 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"link":"https://id.workos.com/portal/launch?secret=secret"}'
+    http_version:
+  recorded_at: Wed, 09 Sep 2020 23:43:07 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description

Adding the domain verification intent as an option for admin portal link generation

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
