### PR TITLE
add last_sign_in_at to user

### DIFF
--- a/lib/workos/user.rb
+++ b/lib/workos/user.rb
@@ -8,7 +8,7 @@ module WorkOS
     include HashProvider
 
     attr_accessor :id, :email, :first_name, :last_name, :email_verified,
-                  :profile_picture_url, :created_at, :updated_at
+                  :profile_picture_url, :last_sign_in_at, :created_at, :updated_at
 
     def initialize(json)
       hash = JSON.parse(json, symbolize_names: true)
@@ -19,6 +19,7 @@ module WorkOS
       @last_name = hash[:last_name]
       @email_verified = hash[:email_verified]
       @profile_picture_url = hash[:profile_picture_url]
+      @last_sign_in_at = hash[:last_sign_in_at]
       @created_at = hash[:created_at]
       @updated_at = hash[:updated_at]
     end
@@ -31,6 +32,7 @@ module WorkOS
         last_name: last_name,
         email_verified: email_verified,
         profile_picture_url: profile_picture_url,
+        last_sign_in_at: last_sign_in_at,
         created_at: created_at,
         updated_at: updated_at,
       }

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -229,6 +229,12 @@ describe WorkOS::UserManagement do
 
           expect(user.id.instance_of?(String))
           expect(user.instance_of?(WorkOS::User))
+          expect(user.first_name).to eq('Bob')
+          expect(user.last_name).to eq('Loblaw')
+          expect(user.email).to eq('bob@example.com')
+          expect(user.email_verified).to eq(false)
+          expect(user.profile_picture_url).to eq(nil)
+          expect(user.last_sign_in_at).to eq('2024-02-06T23:13:18.137Z')
         end
       end
     end

--- a/spec/support/fixtures/vcr_cassettes/user_management/get_user.yml
+++ b/spec/support/fixtures/vcr_cassettes/user_management/get_user.yml
@@ -76,7 +76,7 @@ http_interactions:
       - cloudflare
     body:
       encoding: ASCII-8BIT
-      string: '{"object":"user","id":"user_01HP0B4ZV2FWWVY0BF16GFDAER","email":"bob@example.com","email_verified":false,"first_name":"Bob","last_name":"Loblaw","profile_picture_url":null,"created_at":"2024-02-06T23:13:18.137Z","updated_at":"2024-02-06T23:13:36.946Z"}'
+      string: '{"object":"user","id":"user_01HP0B4ZV2FWWVY0BF16GFDAER","email":"bob@example.com","email_verified":false,"first_name":"Bob","last_name":"Loblaw","profile_picture_url":null,"last_sign_in_at":"2024-02-06T23:13:18.137Z","created_at":"2024-02-06T23:13:18.137Z","updated_at":"2024-02-06T23:13:36.946Z"}'
     http_version:
   recorded_at: Tue, 06 Feb 2024 23:16:59 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
## Description
https://linear.app/workos/issue/AUTH-4177/update-workos-ruby-sdk-for-last-sign-in-at

adds `last_sign_in_at` to user

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```
If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

docs PR: https://github.com/workos/workos/pull/35170
