### PR TITLE
Add email standard attribute to DirectoryUser and mark deprecated standard attributes

### DIFF
--- a/lib/workos/directory_user.rb
+++ b/lib/workos/directory_user.rb
@@ -7,7 +7,7 @@ module WorkOS
   class DirectoryUser < DeprecatedHashWrapper
     include HashProvider
 
-    attr_accessor :id, :idp_id, :emails, :first_name, :last_name, :job_title, :username, :state,
+    attr_accessor :id, :idp_id, :email, :emails, :first_name, :last_name, :job_title, :username, :state,
                   :groups, :role, :custom_attributes, :raw_attributes, :directory_id, :organization_id,
                   :created_at, :updated_at
 
@@ -19,10 +19,20 @@ module WorkOS
       @directory_id = hash[:directory_id]
       @organization_id = hash[:organization_id]
       @idp_id = hash[:idp_id]
+      @email = hash[:email]
+      # @deprecated Will be removed in a future major version.
+      # Enable the `emails` custom attribute in dashboard and pull from customAttributes instead.
+      # See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
       @emails = hash[:emails]
       @first_name = hash[:first_name]
       @last_name = hash[:last_name]
+      # @deprecated Will be removed in a future major version.
+      # Enable the `job_title` custom attribute in dashboard and pull from customAttributes instead.
+      # See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
       @job_title = hash[:job_title]
+      # @deprecated Will be removed in a future major version.
+      # Enable the `username` custom attribute in dashboard and pull from customAttributes instead.
+      # See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
       @username = hash[:username]
       @state = hash[:state]
       @groups = hash[:groups]
@@ -42,6 +52,7 @@ module WorkOS
         directory_id: directory_id,
         organization_id: organization_id,
         idp_id: idp_id,
+        email: email,
         emails: emails,
         first_name: first_name,
         last_name: last_name,
@@ -57,6 +68,7 @@ module WorkOS
       }
     end
 
+    # @deprecated Will be removed in a future major version. Use {#email} instead.
     def primary_email
       primary_email = (emails || []).find { |email| email[:primary] }
       return primary_email[:value] if primary_email


### PR DESCRIPTION
## Description
Add email standard attribute to DirectoryUser and mark deprecated standard attributes.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
