### PR TITLE
add missing session param to authenticate_with methods

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -278,9 +278,23 @@ module WorkOS
       # @param [String] client_id The WorkOS client ID for the environment
       # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
+      # @param [Hash] session An optional hash that determines whether the session should be sealed and
+      # the optional cookie password.
       #
       # @return WorkOS::AuthenticationResponse
-      def authenticate_with_password(email:, password:, client_id:, ip_address: nil, user_agent: nil)
+      def authenticate_with_password(
+        email:,
+        password:,
+        client_id:,
+        ip_address: nil,
+        user_agent: nil,
+        session: nil
+      )
+
+        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
+          raise ArgumentError, 'cookie_password is required when sealing session'
+        end
+
         response = execute_request(
           request: post_request(
             path: '/user_management/authenticate',
@@ -296,7 +310,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::AuthenticationResponse.new(response.body)
+        WorkOS::AuthenticationResponse.new(response.body, session)
       end
 
       # Authenticate a user using OAuth or an organization's SSO connection.
@@ -388,6 +402,8 @@ module WorkOS
       # @param [String] link_authorization_code Used to link an OAuth profile to an existing user,
       # after having completed a Magic Code challenge.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
+      # @param [Hash] session An optional hash that determines whether the session should be sealed and
+      # the optional cookie password.
       #
       # @return WorkOS::AuthenticationResponse
       def authenticate_with_magic_auth(
@@ -396,8 +412,13 @@ module WorkOS
         client_id:,
         ip_address: nil,
         user_agent: nil,
-        link_authorization_code: nil
+        link_authorization_code: nil,
+        session: nil
       )
+        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
+          raise ArgumentError, 'cookie_password is required when sealing session'
+        end
+
         response = execute_request(
           request: post_request(
             path: '/user_management/authenticate',
@@ -414,7 +435,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::AuthenticationResponse.new(response.body)
+        WorkOS::AuthenticationResponse.new(response.body, session)
       end
 
       # Authenticate a user into an organization they are a member of.
@@ -424,6 +445,8 @@ module WorkOS
       # @param [String] pending_authentication_token The pending authentication token
       # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
+      # @param [Hash] session An optional hash that determines whether the session should be sealed and
+      # the optional cookie password.
       #
       # @return WorkOS::AuthenticationResponse
       def authenticate_with_organization_selection(
@@ -431,8 +454,13 @@ module WorkOS
         organization_id:,
         pending_authentication_token:,
         ip_address: nil,
-        user_agent: nil
+        user_agent: nil,
+        session: nil
       )
+        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
+          raise ArgumentError, 'cookie_password is required when sealing session'
+        end
+
         response = execute_request(
           request: post_request(
             path: '/user_management/authenticate',
@@ -448,7 +476,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::AuthenticationResponse.new(response.body)
+        WorkOS::AuthenticationResponse.new(response.body, session)
       end
 
       # Authenticate a user using TOTP.
@@ -461,6 +489,8 @@ module WorkOS
       # authentication request.
       # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
+      # @param [Hash] session An optional hash that determines whether the session should be sealed and
+      # the optional cookie password.
       #
       # @return WorkOS::AuthenticationResponse
       def authenticate_with_totp(
@@ -469,8 +499,13 @@ module WorkOS
         pending_authentication_token:,
         authentication_challenge_id:,
         ip_address: nil,
-        user_agent: nil
+        user_agent: nil,
+        session: nil
       )
+        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
+          raise ArgumentError, 'cookie_password is required when sealing session'
+        end
+
         response = execute_request(
           request: post_request(
             path: '/user_management/authenticate',
@@ -487,7 +522,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::AuthenticationResponse.new(response.body)
+        WorkOS::AuthenticationResponse.new(response.body, session)
       end
 
       # Authenticate a user using Email Verification Code.
@@ -498,6 +533,8 @@ module WorkOS
       # authentication attempt due to an unverified email address.
       # @param [String] ip_address The IP address of the request from the user who is attempting to authenticate.
       # @param [String] user_agent The user agent of the request from the user who is attempting to authenticate.
+      # @param [Hash] session An optional hash that determines whether the session should be sealed and
+      # the optional cookie password.
       #
       # @return WorkOS::AuthenticationResponse
       def authenticate_with_email_verification(
@@ -505,8 +542,13 @@ module WorkOS
         client_id:,
         pending_authentication_token:,
         ip_address: nil,
-        user_agent: nil
+        user_agent: nil,
+        session: nil
       )
+        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
+          raise ArgumentError, 'cookie_password is required when sealing session'
+        end
+
         response = execute_request(
           request: post_request(
             path: '/user_management/authenticate',
@@ -522,7 +564,7 @@ module WorkOS
           ),
         )
 
-        WorkOS::AuthenticationResponse.new(response.body)
+        WorkOS::AuthenticationResponse.new(response.body, session)
       end
 
       # Get the logout URL for a session

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -399,6 +399,7 @@ module WorkOS
       # the optional cookie password.
       #
       # @return WorkOS::AuthenticationResponse
+      # rubocop:disable Metrics/ParameterLists
       def authenticate_with_magic_auth(
         code:,
         email:,
@@ -428,6 +429,7 @@ module WorkOS
 
         WorkOS::AuthenticationResponse.new(response.body, session)
       end
+      # rubocop:enable Metrics/ParameterLists
 
       # Authenticate a user into an organization they are a member of.
       #
@@ -482,6 +484,7 @@ module WorkOS
       # the optional cookie password.
       #
       # @return WorkOS::AuthenticationResponse
+      # rubocop:disable Metrics/ParameterLists
       def authenticate_with_totp(
         code:,
         client_id:,
@@ -511,6 +514,7 @@ module WorkOS
 
         WorkOS::AuthenticationResponse.new(response.body, session)
       end
+      # rubocop:enable Metrics/ParameterLists
 
       # Authenticate a user using Email Verification Code.
       #
@@ -1110,9 +1114,9 @@ module WorkOS
       private
 
       def validate_session(session)
-        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
-          raise ArgumentError, 'cookie_password is required when sealing session'
-        end
+        return unless session && (session[:seal_session] == true) && session[:cookie_password].nil?
+
+        raise ArgumentError, 'cookie_password is required when sealing session'
       end
 
       def validate_authorization_url_arguments(

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -290,10 +290,7 @@ module WorkOS
         user_agent: nil,
         session: nil
       )
-
-        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
-          raise ArgumentError, 'cookie_password is required when sealing session'
-        end
+        validate_session(session)
 
         response = execute_request(
           request: post_request(
@@ -331,9 +328,7 @@ module WorkOS
         user_agent: nil,
         session: nil
       )
-        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
-          raise ArgumentError, 'cookie_password is required when sealing session'
-        end
+        validate_session(session)
 
         response = execute_request(
           request: post_request(
@@ -371,9 +366,7 @@ module WorkOS
         user_agent: nil,
         session: nil
       )
-        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
-          raise ArgumentError, 'cookie_password is required when sealing session'
-        end
+        validate_session(session)
 
         response = execute_request(
           request: post_request(
@@ -415,9 +408,7 @@ module WorkOS
         link_authorization_code: nil,
         session: nil
       )
-        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
-          raise ArgumentError, 'cookie_password is required when sealing session'
-        end
+        validate_session(session)
 
         response = execute_request(
           request: post_request(
@@ -457,9 +448,7 @@ module WorkOS
         user_agent: nil,
         session: nil
       )
-        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
-          raise ArgumentError, 'cookie_password is required when sealing session'
-        end
+        validate_session(session)
 
         response = execute_request(
           request: post_request(
@@ -502,9 +491,7 @@ module WorkOS
         user_agent: nil,
         session: nil
       )
-        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
-          raise ArgumentError, 'cookie_password is required when sealing session'
-        end
+        validate_session(session)
 
         response = execute_request(
           request: post_request(
@@ -545,9 +532,7 @@ module WorkOS
         user_agent: nil,
         session: nil
       )
-        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
-          raise ArgumentError, 'cookie_password is required when sealing session'
-        end
+        validate_session(session)
 
         response = execute_request(
           request: post_request(
@@ -1123,6 +1108,12 @@ module WorkOS
       end
 
       private
+
+      def validate_session(session)
+        if session && (session[:seal_session] == true) && session[:cookie_password].nil?
+          raise ArgumentError, 'cookie_password is required when sealing session'
+        end
+      end
 
       def validate_authorization_url_arguments(
         provider:,


### PR DESCRIPTION
## Description
Add missing session param to authenticate methods.

`authenticate_with_password`
`authenticate_with_magic_auth`
`authenticate_with_organization_selection`
`authenticate_with_totp`
`authenticate_with_email_verification`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
