### PR TITLE
docs: Fix parameter name in DirectorySync#list_users documentation

### DIFF
--- a/lib/workos/directory_sync.rb
+++ b/lib/workos/directory_sync.rb
@@ -115,7 +115,7 @@ module WorkOS
       # @param [Hash] options An options hash
       # @option options [String] directory The ID of the directory whose
       #  directory users will be retrieved.
-      # @option options [String] user The ID of the directory group whose
+      # @option options [String] group The ID of the directory group whose
       #  directory users will be retrieved.
       # @option options [String] limit Maximum number of records to return.
       # @option options [String] order The order in which to paginate records


### PR DESCRIPTION
## Description
The parameter name in the documentation was incorrectly listed as `user` when it should be `group` according to the folloiwing API reference documentation.
https://workos.com/docs/reference/directory-sync/directory-user/list



## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
