### PR TITLE
Fix request body construction to only send non-nil values

### DIFF
--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -206,7 +206,7 @@ module WorkOS
             email_verified: email_verified,
             password_hash: password_hash,
             password_hash_type: password_hash_type,
-          },
+          }.compact,
           auth: true,
         )
 
@@ -643,7 +643,7 @@ module WorkOS
             body: {
               email: email,
               invitation_token: invitation_token,
-            },
+            }.compact,
             auth: true,
           ),
         )
@@ -697,7 +697,7 @@ module WorkOS
               totp_issuer: totp_issuer,
               totp_user: totp_user,
               totp_secret: totp_secret,
-            },
+            }.compact,
             auth: true,
           ),
         )
@@ -928,7 +928,7 @@ module WorkOS
             user_id: user_id,
             organization_id: organization_id,
             role_slug: role_slug,
-          },
+          }.compact,
           auth: true,
         )
 
@@ -1093,7 +1093,7 @@ module WorkOS
               expires_in_days: expires_in_days,
               inviter_user_id: inviter_user_id,
               role_slug: role_slug,
-            },
+            }.compact,
             auth: true,
           ),
         )

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -251,7 +251,7 @@ module WorkOS
             password: password,
             password_hash: password_hash,
             password_hash_type: password_hash_type,
-          },
+          }.compact,
           auth: true,
         )
 

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -338,6 +338,26 @@ describe WorkOS::UserManagement do
         end
       end
 
+      it 'only sends non-nil values in request body' do
+        expect(described_class).to receive(:post_request) do |options|
+          body = options[:body]
+          expect(body).to eq({ email: 'test@example.com', first_name: 'John' })
+          expect(body).not_to have_key(:last_name)
+          expect(body).not_to have_key(:email_verified)
+          
+          double('request')
+        end.and_return(double('request'))
+        
+        expect(described_class).to receive(:execute_request).and_return(
+          double('response', body: '{"id": "test_user", "email": "test@example.com"}')
+        )
+        
+        described_class.create_user(
+          email: 'test@example.com',
+          first_name: 'John'
+        )
+      end
+
       context 'with an invalid payload' do
         it 'returns an error' do
           VCR.use_cassette 'user_management/create_user_invalid' do
@@ -801,6 +821,27 @@ describe WorkOS::UserManagement do
           expect(authentication_response.authentication_factor.id).to eq('auth_factor_01H96FETXENNY99ARX0GRC804C')
           expect(authentication_response.authentication_challenge.id).to eq('auth_challenge_01H96FETXGTW1QMBSBT2T36PW0')
         end
+      end
+
+      it 'only sends non-nil values in request body' do
+        expect(described_class).to receive(:post_request) do |options|
+          body = options[:body]
+          expect(body).to eq({ type: 'totp', totp_issuer: 'Test App' })
+          expect(body).not_to have_key(:totp_user)
+          expect(body).not_to have_key(:totp_secret)
+          
+          double('request')
+        end.and_return(double('request'))
+        
+        expect(described_class).to receive(:execute_request).and_return(
+          double('response', body: '{"authentication_factor": {"id": "test"}, "authentication_challenge": {"id": "test"}}')
+        )
+        
+        described_class.enroll_auth_factor(
+          user_id: 'user_123',
+          type: 'totp',
+          totp_issuer: 'Test App'
+        )
       end
     end
 
@@ -1467,6 +1508,27 @@ describe WorkOS::UserManagement do
           expect(invitation.id).to eq('invitation_01H5JQDV7R7ATEYZDEG0W5PRYS')
           expect(invitation.email).to eq('test@workos.com')
         end
+      end
+
+      it 'only sends non-nil values in request body' do
+        expect(described_class).to receive(:post_request) do |options|
+          body = options[:body]
+          expect(body).to eq({ email: 'test@workos.com', organization_id: 'org_123' })
+          expect(body).not_to have_key(:expires_in_days)
+          expect(body).not_to have_key(:inviter_user_id)
+          expect(body).not_to have_key(:role_slug)
+          
+          double('request')
+        end.and_return(double('request'))
+        
+        expect(described_class).to receive(:execute_request).and_return(
+          double('response', body: '{"id": "test_invitation"}')
+        )
+
+        described_class.send_invitation(
+          email: 'test@workos.com',
+          organization_id: 'org_123'
+        )
       end
     end
 

--- a/spec/lib/workos/user_management_spec.rb
+++ b/spec/lib/workos/user_management_spec.rb
@@ -382,6 +382,30 @@ describe WorkOS::UserManagement do
         end
       end
 
+      it 'only sends non-nil values in request body' do
+        # Mock the request to inspect what's being sent
+        expect(described_class).to receive(:put_request) do |options|
+          # Verify that the body only contains non-nil values
+          body = options[:body]
+          expect(body).to eq({ email_verified: true })
+          expect(body).not_to have_key(:first_name)
+          expect(body).not_to have_key(:last_name)
+          expect(body).not_to have_key(:email)
+          
+          # Return a mock request object
+          double('request')
+        end.and_return(double('request'))
+        
+        expect(described_class).to receive(:execute_request).and_return(
+          double('response', body: '{"id": "test_user", "email_verified": true}')
+        )
+        
+        described_class.update_user(
+          id: 'user_01H7TVSKS45SDHN5V9XPSM6H44',
+          email_verified: true
+        )
+      end
+
       context 'with an invalid payload' do
         it 'returns an error' do
           VCR.use_cassette 'user_management/update_user/invalid' do


### PR DESCRIPTION
## Summary
Fix multiple methods in the UserManagement module to use `.compact` when building request bodies, preventing unnecessary nil values from being sent to the API.

This addresses a customer-reported issue where `update_user` was unintentionally nullifying fields that weren't explicitly provided. The fix has been extended to all similar methods for consistency.

## What was the problem?
When calling methods like `update_user` with only some parameters:
```ruby
WorkOS::UserManagement.update_user(
  id: 'user_123',
  email_verified: true
)
```

The method was sending ALL parameters (including nil ones) to the API:
```ruby
{
  email: nil,
  first_name: nil, 
  last_name: nil,
  email_verified: true,
  external_id: nil,
  # ... more nil values
}
```

This caused the API to explicitly nullify fields that users didn't intend to change.

## What's the solution?
Add `.compact` to remove nil values before sending the request:
```ruby
{
  email_verified: true  # Only non-nil values sent
}
```

## Methods Fixed
- `update_user` - Critical fix for user-reported issue
- `create_user` - Consistency and best practice
- `send_invitation` - Remove unnecessary nil invitation parameters  
- `enroll_auth_factor` - Remove unnecessary nil TOTP parameters
- `create_organization_membership` - Remove unnecessary nil role_slug
- `create_magic_auth` - Remove unnecessary nil invitation_token

## Test plan
- [x] All existing tests pass (353/353 examples)
- [x] Added specific tests to verify only non-nil values are sent
- [x] No regressions introduced
- [x] Follows existing pattern used in `authorization_url` method

## Backward compatibility
✅ **This is a PATCH-level change** - bug fixes only, no breaking changes
- Method signatures unchanged
- Behavior improved (fixes incorrect nullification)
- All existing code will work better, not break

## Pattern consistency
This change makes all methods follow the same pattern already established in the codebase at `authorization_url:121` which uses `.compact`.