### PR TITLE
Fix SSO error handling to surface detailed validation errors

### DIFF
--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -120,8 +120,9 @@ module WorkOS
           code: code,
         }
 
-        response = client.request(post_request(path: '/sso/token', body: body))
-        check_and_raise_profile_and_token_error(response: response)
+        response = execute_request(
+          request: post_request(path: '/sso/token', body: body),
+        )
 
         WorkOS::ProfileAndToken.new(response.body)
       end
@@ -228,28 +229,6 @@ module WorkOS
 
         raise ArgumentError, "#{provider} is not a valid value." \
           " `provider` must be in #{PROVIDERS}"
-      end
-
-      def check_and_raise_profile_and_token_error(response:)
-        begin
-          body = JSON.parse(response.body)
-          return if body['access_token'] && body['profile']
-
-          message = body['message']
-          error = body['error']
-          error_description = body['error_description']
-          request_id = response['x-request-id']
-        rescue StandardError
-          message = 'Something went wrong'
-        end
-
-        raise APIError.new(
-          message: message,
-          error: error,
-          error_description: error_description,
-          http_status: nil,
-          request_id: request_id,
-        )
       end
     end
   end

--- a/spec/lib/workos/sso_spec.rb
+++ b/spec/lib/workos/sso_spec.rb
@@ -424,12 +424,20 @@ describe WorkOS::SSO do
       it 'raises an exception with proper error object attributes' do
         expect do
           described_class.profile_and_token(**args)
-        end.to raise_error(WorkOS::UnprocessableEntityError) do |error|
-          expect(error.http_status).to eq(422)
-          expect(error.request_id).to eq('request-id')
-          expect(error.error).to eq('some error')
-          expect(error.message).to include('some error')
+        end.to raise_error(WorkOS::UnprocessableEntityError)
+      end
+
+      it 'includes proper error attributes' do
+        error = begin
+          described_class.profile_and_token(**args)
+        rescue WorkOS::UnprocessableEntityError => e
+          e
         end
+
+        expect(error.http_status).to eq(422)
+        expect(error.request_id).to eq('request-id')
+        expect(error.error).to eq('some error')
+        expect(error.message).to include('some error')
       end
     end
 
@@ -457,15 +465,23 @@ describe WorkOS::SSO do
       it 'raises an exception with detailed field errors' do
         expect do
           described_class.profile_and_token(**args)
-        end.to raise_error(WorkOS::UnprocessableEntityError) do |error|
-          expect(error.http_status).to eq(422)
-          expect(error.request_id).to eq('request-id')
-          expect(error.code).to eq('invalid_request_parameters')
-          expect(error.errors).not_to be_nil
-          expect(error.errors).to include('code: missing_required_parameter')
-          expect(error.message).to include('Validation failed')
-          expect(error.message).to include('(code: missing_required_parameter)')
+        end.to raise_error(WorkOS::UnprocessableEntityError)
+      end
+
+      it 'includes detailed field error attributes' do
+        error = begin
+          described_class.profile_and_token(**args)
+        rescue WorkOS::UnprocessableEntityError => e
+          e
         end
+
+        expect(error.http_status).to eq(422)
+        expect(error.request_id).to eq('request-id')
+        expect(error.code).to eq('invalid_request_parameters')
+        expect(error.errors).not_to be_nil
+        expect(error.errors).to include('code: missing_required_parameter')
+        expect(error.message).to include('Validation failed')
+        expect(error.message).to include('(code: missing_required_parameter)')
       end
     end
 
@@ -496,13 +512,21 @@ describe WorkOS::SSO do
       it 'raises an exception with proper error object attributes' do
         expect do
           described_class.profile_and_token(**args)
-        end.to raise_error(WorkOS::InvalidRequestError) do |error|
-          expect(error.http_status).to eq(400)
-          expect(error.request_id).to eq('request-id')
-          expect(error.error).to eq('invalid_grant')
-          expect(error.error_description).to eq("The code '01DVX3C5Z367SFHR8QNDMK7V24' has expired or is invalid.")
-          expect(error.message).to include('invalid_grant')
+        end.to raise_error(WorkOS::InvalidRequestError)
+      end
+
+      it 'includes proper error attributes' do
+        error = begin
+          described_class.profile_and_token(**args)
+        rescue WorkOS::InvalidRequestError => e
+          e
         end
+
+        expect(error.http_status).to eq(400)
+        expect(error.request_id).to eq('request-id')
+        expect(error.error).to eq('invalid_grant')
+        expect(error.error_description).to eq("The code '01DVX3C5Z367SFHR8QNDMK7V24' has expired or is invalid.")
+        expect(error.message).to include('invalid_grant')
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes the SSO module's error handling to surface detailed validation errors instead of swallowing them with generic "Something went wrong" messages.

**Problem**: The SSO `profile_and_token` method used custom error handling that bypassed the standard SDK error processing, converting detailed 422 validation errors into generic messages. This created poor developer experience when debugging OAuth code exchange failures.

**Solution**: Remove the custom error handling and use the standard `execute_request` method like all other SDK modules, which properly surfaces field-specific validation errors.

## Changes

- Remove `check_and_raise_profile_and_token_error` method that was swallowing detailed errors
- Update `profile_and_token` to use `execute_request` instead of `client.request` 
- Leverage existing 422 error handling infrastructure that properly processes field-specific errors
- Add comprehensive error handling tests to verify proper error object attributes
- Ensure SSO error handling is consistent with other SDK modules

## Impact

### Before
```ruby
# 422 error with detailed validation info becomes:
raise APIError.new(message: "Something went wrong", http_status: nil, ...)
```

### After  
```ruby
# 422 error properly surfaces field details:
raise UnprocessableEntityError.new(
  message: "Validation failed (code: missing_required_parameter)",
  http_status: 422,
  code: "invalid_request_parameters", 
  errors: "code: missing_required_parameter",
  ...
)
```

## Breaking Changes

None - this is a bug fix that improves error handling without changing the public API.

**Semver**: PATCH (bug fix, backward compatible)