### PR TITLE
Include decoded Feature Flags from the JWT into the payload of a WorkOS Session

### DIFF
--- a/lib/workos/session.rb
+++ b/lib/workos/session.rb
@@ -51,6 +51,7 @@ module WorkOS
         role: decoded['role'],
         permissions: decoded['permissions'],
         entitlements: decoded['entitlements'],
+        feature_flags: decoded['feature_flags'],
         user: session[:user],
         impersonator: session[:impersonator],
         reason: nil,

--- a/spec/lib/workos/session_spec.rb
+++ b/spec/lib/workos/session_spec.rb
@@ -174,6 +174,7 @@ describe WorkOS::Session do
                              organization_id: 'org_id',
                              role: 'role',
                              permissions: ['read'],
+                             feature_flags: nil,
                              entitlements: nil,
                              user: 'user',
                              impersonator: 'impersonator',
@@ -209,6 +210,43 @@ describe WorkOS::Session do
                                role: 'role',
                                permissions: ['read'],
                                entitlements: ['billing'],
+                               feature_flags: nil,
+                               user: 'user',
+                               impersonator: 'impersonator',
+                               reason: nil,
+                             })
+      end
+    end
+
+    describe 'with feature flags' do
+      let(:payload) do
+        {
+          sid: 'session_id',
+          org_id: 'org_id',
+          role: 'role',
+          permissions: ['read'],
+          feature_flags: ['new_feature_enabled'],
+          exp: Time.now.to_i + 3600,
+        }
+      end
+
+      it 'includes feature flags in the result' do
+        session = WorkOS::Session.new(
+          user_management: user_management,
+          client_id: client_id,
+          session_data: session_data,
+          cookie_password: cookie_password,
+        )
+        allow_any_instance_of(JWT::Decode).to receive(:verify_signature).and_return(true)
+        result = session.authenticate
+        expect(result).to eq({
+                               authenticated: true,
+                               session_id: 'session_id',
+                               organization_id: 'org_id',
+                               role: 'role',
+                               permissions: ['read'],
+                               entitlements: nil,
+                               feature_flags: ['new_feature_enabled'],
                                user: 'user',
                                impersonator: 'impersonator',
                                reason: nil,


### PR DESCRIPTION
## Description

Feature Flags are defined in the environment and enabled but are not exposed but the library, although already existing in the JWT payload.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

Based on the docs at https://workos.com/blog/feature-flags, it must include the property `session[:feature_flags]` to collect the list of existing Feature Flags extracted from the JWT.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
