### PR TITLE
v5.22.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workos (5.21.0)
+    workos (5.22.0)
       encryptor (~> 3.0)
       jwt (~> 2.8)
 

--- a/lib/workos/version.rb
+++ b/lib/workos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WorkOS
-  VERSION = '5.21.0'
+  VERSION = '5.22.0'
 end


### PR DESCRIPTION
## Description

This pull request updates the version of the `WorkOS` library to reflect new changes or improvements.

Version update:

* [`lib/workos/version.rb`](diffhunk://#diff-b484d50ac8ccba6ee04f0c7de8d87e3b4ba1005d4d7c26bfee8f5d927a8db97cL4-R4): Incremented the version from `5.21.0` to `5.22.0`.

- #385 
- #384 
- #386

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
