### PR TITLE
Add SSO and Domain Verification widget scopes

### DIFF
--- a/lib/workos/types/widget_scope.rb
+++ b/lib/workos/types/widget_scope.rb
@@ -6,8 +6,10 @@ module WorkOS
     # scopes while generating a widget token.
     module WidgetScope
       USERS_TABLE_MANAGE = 'widgets:users-table:manage'
+      SSO_MANAGE = 'widgets:sso:manage'
+      DOMAIN_VERIFICATION_MANAGE = 'widgets:domain-verification:manage'
 
-      ALL = [USERS_TABLE_MANAGE].freeze
+      ALL = [USERS_TABLE_MANAGE, SSO_MANAGE, DOMAIN_VERIFICATION_MANAGE].freeze
     end
   end
 end


### PR DESCRIPTION
Allowing these widgets to be used via the `WorkOS::Widgets.get_token` API.

- https://workos.com/docs/widgets/admin-portal-sso-connection
- https://workos.com/docs/widgets/admin-portal-domain-verification

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

- [ ] Yes
- [x] No

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
