### PR TITLE
fix: update Zeitwerk autoload for inflections.rb

### DIFF
--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -30,6 +30,7 @@ loader.collapse("#{__dir__}/workos/vault")
 loader.collapse("#{__dir__}/workos/webhooks")
 loader.collapse("#{__dir__}/workos/widgets")
 loader.ignore("#{__dir__}/workos/errors.rb")
+loader.ignore("#{__dir__}/workos/inflections.rb")
 loader.setup
 
 require "workos/errors"


### PR DESCRIPTION
## Summary
- Tell Zeitwerk to ignore `inflections.rb`, which defines a plain constant (`WORKOS_INFLECTIONS`) rather than a class/module matching the file name
- Without this, Zeitwerk expects `inflections.rb` to define an `Inflections` constant and raises a `NameError` on load

Closes https://github.com/workos/workos-ruby/issues/459.

## Test plan
- [ ] `bundle exec rake` passes with no Zeitwerk `NameError`
- [ ] Inflection overrides still apply correctly (classes with non-standard casing like `AuthenticationMFAFailed` resolve)