### PR TITLE
fix: eagerly load configuration.rb to fix WorkOS.configure

### DIFF
--- a/.oagen-manifest.json
+++ b/.oagen-manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "language": "ruby",
-  "generatedAt": "2026-04-27T20:38:15.866Z",
+  "generatedAt": "2026-04-27T20:55:49.741Z",
   "files": [
     "lib/workos.rb",
     "lib/workos/admin_portal.rb",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Or configure the SDK in an initializer:
 # /config/initializers/workos.rb
 
 require "workos"
-require "workos/configuration"
 
 WorkOS.configure do |config|
   config.api_key = ENV.fetch("WORKOS_API_KEY")

--- a/lib/workos.rb
+++ b/lib/workos.rb
@@ -32,6 +32,8 @@ loader.collapse("#{__dir__}/workos/webhooks")
 loader.collapse("#{__dir__}/workos/widgets")
 loader.ignore("#{__dir__}/workos/errors.rb")
 loader.ignore("#{__dir__}/workos/inflections.rb")
+loader.ignore("#{__dir__}/workos/configuration.rb")
 loader.setup
 
 require "workos/errors"
+require "workos/configuration"


### PR DESCRIPTION
## Summary
- Adds `configuration.rb` to the list of hand-maintained files ignored by Zeitwerk and explicitly required
- Follows the same pattern already used for `errors.rb` and `inflections.rb`
- Zeitwerk only autoloads on constant access, not method calls — so `WorkOS.configure` was unavailable until something happened to reference `WorkOS::Configuration` first

Fixes #462

## Test plan
- [ ] Confirm `WorkOS.configure { |c| ... }` works immediately after `require 'workos'` without needing an explicit `require 'workos/configuration'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)