### PR TITLE
fix: prevent partial state mutation in Session#refresh

### DIFF
--- a/lib/workos/session.rb
+++ b/lib/workos/session.rb
@@ -104,10 +104,13 @@ module WorkOS
         user: auth_response["user"],
         impersonator: auth_response["impersonator"]
       )
+
+      # Decode before mutating session state so a malformed access_token
+      # doesn't leave the Session half-updated.
+      decoded = @manager.decode_jwt(auth_response["access_token"])
+
       @seal_data = sealed
       @cookie_password = effective_password
-
-      decoded = @manager.decode_jwt(auth_response["access_token"])
       SessionManager::RefreshSuccess.new(
         authenticated: true,
         sealed_session: sealed,
@@ -122,6 +125,8 @@ module WorkOS
         feature_flags: decoded["feature_flags"]
       )
     rescue WorkOS::AuthenticationError, WorkOS::InvalidRequestError => e
+      SessionManager::RefreshError.new(authenticated: false, reason: e.message)
+    rescue JWT::DecodeError => e
       SessionManager::RefreshError.new(authenticated: false, reason: e.message)
     end
 

--- a/test/workos/test_session.rb
+++ b/test/workos/test_session.rb
@@ -305,6 +305,32 @@ class SessionTest < Minitest::Test
     assert_requested(stub)
   end
 
+  def test_refresh_returns_error_on_malformed_access_token_without_mutating_state
+    rsa, pub = signing_key_pair
+    old_access = make_jwt({"sid" => "session_old", "exp" => Time.now.to_i - 60}, rsa)
+    sealed = @sm.seal_data({"access_token" => old_access, "refresh_token" => "rt_old", "user" => {"id" => "u_1"}}, PASSWORD)
+
+    api_response = {
+      "access_token" => "not-a-valid-jwt",
+      "refresh_token" => "rt_new",
+      "user" => {"id" => "u_1"}
+    }
+
+    stub_request(:post, "https://api.workos.com/user_management/authenticate")
+      .to_return(status: 200, body: api_response.to_json)
+    stub_request(:get, "https://api.workos.com/sso/jwks/client_001")
+      .to_return(status: 200, body: jwks_payload(pub).to_json)
+
+    session = @sm.load(seal_data: sealed, cookie_password: PASSWORD)
+    result = session.refresh
+
+    assert_kind_of WorkOS::SessionManager::RefreshError, result
+    refute result.authenticated
+
+    # Session state should not have been mutated
+    assert_equal sealed, session.seal_data
+  end
+
   # --- Session constructor validation ---------------------------------------
 
   def test_session_load_requires_cookie_password


### PR DESCRIPTION
## Summary

Follow-up to #470, addressing Greptile's P2 finding about state mutation ordering.

- Moves `decode_jwt` call **before** `@seal_data`/`@cookie_password` assignment, so a malformed `access_token` from the API doesn't leave the `Session` object half-updated.
- Adds `rescue JWT::DecodeError` so callers get a `RefreshError` instead of an unhandled exception.
- Adds a test that verifies `seal_data` is unchanged after a failed decode.

**Re: Greptile's P2 about `iss`/`aud` validation** — intentionally not addressed here. Every WorkOS SDK (Ruby, Python, Node, Go, .NET) deliberately skips `iss`/`aud` verification because the JWT lives inside an AES-256-GCM sealed cookie; the unseal step already authenticates the data. Adding claim verification would break cross-SDK consistency without meaningful security benefit.

## Test plan

- [x] `test_refresh_returns_error_on_malformed_access_token_without_mutating_state` — API returns garbage `access_token`, session state is preserved, caller gets `RefreshError`
- [x] Full suite passes (858 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)