### PR TITLE
fix: set canonical User-Agent header format

### DIFF
--- a/lib/workos/base_client.rb
+++ b/lib/workos/base_client.rb
@@ -34,7 +34,12 @@ module WorkOS
     RETRY_BACKOFF_BASE = 0.5
     LOG_SEVERITY = {debug: 0, info: 1, warn: 2, error: 3, unknown: 4}.freeze
 
-    USER_AGENT = "workos-ruby/#{WorkOS::VERSION} ruby/#{RUBY_VERSION} (#{RUBY_PLATFORM})"
+    USER_AGENT = [
+      "WorkOS",
+      "#{defined?(::RUBY_ENGINE) ? ::RUBY_ENGINE : "ruby"}/#{RUBY_VERSION}",
+      RUBY_PLATFORM,
+      "v#{WorkOS::VERSION}"
+    ].join("; ").freeze
 
     attr_reader :api_key, :base_url, :client_id, :timeout, :max_retries, :logger, :log_level
 


### PR DESCRIPTION
## Summary

Sets the outgoing `User-Agent` header to `WorkOS; {engine}/{ruby_version}; {platform}; v{VERSION}` — the canonical WorkOS Ruby SDK format used through the 6.x line. The 7.0.0 release inadvertently shipped a different shape (`workos-ruby/{VERSION} ruby/{ruby_version} ({platform})`) that no longer conformed.

The new format also includes the Ruby engine name via `RUBY_ENGINE`, so traffic from JRuby and TruffleRuby is now distinguishable from MRI in the `User-Agent` header.

Example UAs:

- MRI: `WorkOS; ruby/3.3.11; arm64-darwin25; v7.1.1`
- JRuby: `WorkOS; jruby/9.4.0.0; java; v7.1.1`
- TruffleRuby: `WorkOS; truffleruby/24.0.0; arm64-darwin; v7.1.1`

## Test plan

- [x] `bundle exec rake test` (870 runs, 4395 assertions, 0 failures)
- [ ] Confirm User-Agent in a real outgoing request

🤖 Generated with [Claude Code](https://claude.com/claude-code)