### PR TITLE
fix: decode legacy v6 sealed sessions on unseal

### DIFF
--- a/lib/workos/encryptors/aes_gcm.rb
+++ b/lib/workos/encryptors/aes_gcm.rb
@@ -27,6 +27,18 @@ module WorkOS
 
       def unseal(sealed, key)
         raw = Base64.decode64(sealed.to_s)
+        decode_v7(raw, key)
+      rescue ArgumentError, OpenSSL::Cipher::CipherError => original_error
+        begin
+          decode_old(raw, key)
+        rescue ArgumentError, OpenSSL::Cipher::CipherError
+          raise original_error
+        end
+      end
+
+      private
+
+      def decode_v7(raw, key)
         raise ArgumentError, "Sealed payload too short" if raw.bytesize < 1 + 12 + 16
         version = raw.byteslice(0, 1).bytes.first
         raise ArgumentError, "Unknown seal version: #{version}" unless version == SEAL_VERSION
@@ -37,7 +49,29 @@ module WorkOS
         cipher.key = derive_key(key)
         cipher.iv = iv
         cipher.auth_tag = tag
-        decoded = cipher.update(ciphertext) + cipher.final
+
+        parse_decoded(cipher.update(ciphertext) + cipher.final)
+      end
+
+      def decode_old(raw, key)
+        # v6 sealed sessions were Base64(iv + ciphertext + auth_tag) using the
+        # `encryptor` gem without the v7 version byte or key derivation.
+        raise ArgumentError, "Legacy sealed payload too short" if raw.bytesize < 12 + 16
+
+        iv = raw.byteslice(0, 12)
+        encrypted = raw.byteslice(12, raw.bytesize - 12)
+        ciphertext = encrypted.byteslice(0, encrypted.bytesize - 16)
+        tag = encrypted.byteslice(encrypted.bytesize - 16, 16)
+
+        cipher = OpenSSL::Cipher.new("aes-256-gcm").decrypt
+        cipher.key = key.to_s
+        cipher.iv = iv
+        cipher.auth_tag = tag
+
+        parse_decoded(cipher.update(ciphertext) + cipher.final)
+      end
+
+      def parse_decoded(decoded)
         decoded.force_encoding(Encoding::UTF_8)
         begin
           JSON.parse(decoded)
@@ -45,8 +79,6 @@ module WorkOS
           decoded
         end
       end
-
-      private
 
       def derive_key(passphrase)
         Digest::SHA256.digest(passphrase.to_s)

--- a/test/workos/test_encryptors_aes_gcm.rb
+++ b/test/workos/test_encryptors_aes_gcm.rb
@@ -3,6 +3,9 @@
 # @oagen-ignore-file
 require "test_helper"
 require "base64"
+require "json"
+require "openssl"
+require "securerandom"
 
 class EncryptorsAesGcmTest < Minitest::Test
   PASSWORD = "test-cookie-password-at-least-32"
@@ -50,5 +53,23 @@ class EncryptorsAesGcmTest < Minitest::Test
     sealed1 = @enc.seal(data, PASSWORD)
     sealed2 = @enc.seal(data, PASSWORD)
     refute_equal sealed1, sealed2
+  end
+
+  def test_unseal_reads_legacy_v6_payload
+    data = {"access_token" => "tok_abc", "refresh_token" => "ref_xyz"}
+    sealed = legacy_v6_seal(data, PASSWORD)
+    assert_equal data, @enc.unseal(sealed, PASSWORD)
+  end
+
+  private
+
+  def legacy_v6_seal(data, key)
+    cipher = OpenSSL::Cipher.new("aes-256-gcm").encrypt
+    iv = SecureRandom.random_bytes(12)
+    cipher.key = key
+    cipher.iv = iv
+    ciphertext = cipher.update(JSON.generate(data)) + cipher.final
+
+    Base64.encode64(iv + ciphertext + cipher.auth_tag)
   end
 end

--- a/test/workos/test_session.rb
+++ b/test/workos/test_session.rb
@@ -6,6 +6,7 @@ require "json"
 require "openssl"
 require "jwt"
 require "base64"
+require "securerandom"
 
 class SessionTest < Minitest::Test
   PASSWORD = "very-long-cookie-password-secret"
@@ -82,6 +83,22 @@ class SessionTest < Minitest::Test
     assert_equal "session_42", result.session_id
     assert_equal "org_1", result.organization_id
     assert_equal "u_1", result.user["id"]
+  end
+
+  def test_authenticate_reads_legacy_v6_sealed_session
+    rsa, pub = signing_key_pair
+    access_token = make_jwt({"sid" => "session_v6", "org_id" => "org_legacy", "exp" => Time.now.to_i + 60}, rsa)
+    sealed = legacy_v6_seal({"access_token" => access_token, "user" => {"id" => "u_legacy"}}, PASSWORD)
+
+    stub_request(:get, "https://api.workos.com/sso/jwks/client_001")
+      .to_return(status: 200, body: jwks_payload(pub).to_json)
+
+    result = @sm.authenticate(seal_data: sealed, cookie_password: PASSWORD)
+    assert_kind_of WorkOS::SessionManager::AuthSuccess, result
+    assert result.authenticated
+    assert_equal "session_v6", result.session_id
+    assert_equal "org_legacy", result.organization_id
+    assert_equal "u_legacy", result.user["id"]
   end
 
   def test_authenticate_merges_custom_claims_from_block
@@ -382,5 +399,17 @@ class SessionTest < Minitest::Test
     result = sm.authenticate(seal_data: sealed, cookie_password: PASSWORD)
     assert_kind_of WorkOS::SessionManager::AuthSuccess, result
     assert_equal "s_custom", result.session_id
+  end
+
+  private
+
+  def legacy_v6_seal(data, key)
+    cipher = OpenSSL::Cipher.new("aes-256-gcm").encrypt
+    iv = SecureRandom.random_bytes(12)
+    cipher.key = key
+    cipher.iv = iv
+    ciphertext = cipher.update(JSON.generate(data)) + cipher.final
+
+    Base64.encode64(iv + ciphertext + cipher.auth_tag)
   end
 end

--- a/test/workos/test_session.rb
+++ b/test/workos/test_session.rb
@@ -261,6 +261,45 @@ class SessionTest < Minitest::Test
     assert_equal "rt_new", unsealed["refresh_token"]
   end
 
+  def test_refresh_reads_legacy_v6_sealed_session
+    rsa, pub = signing_key_pair
+    old_access = make_jwt({"sid" => "session_old_v6", "exp" => Time.now.to_i - 60}, rsa)
+    sealed = legacy_v6_seal(
+      {"access_token" => old_access, "refresh_token" => "rt_old_v6", "user" => {"id" => "u_v6"}},
+      PASSWORD
+    )
+
+    new_access = make_jwt({"sid" => "session_new_v6", "org_id" => "org_v6", "role" => "member", "exp" => Time.now.to_i + 300}, rsa)
+    api_response = {
+      "access_token" => new_access,
+      "refresh_token" => "rt_new_v6",
+      "user" => {"id" => "u_v6", "email" => "legacy@example.com"},
+      "impersonator" => nil
+    }
+
+    stub_request(:post, "https://api.workos.com/user_management/authenticate")
+      .with(body: hash_including("grant_type" => "refresh_token", "refresh_token" => "rt_old_v6"))
+      .to_return(status: 200, body: api_response.to_json)
+    stub_request(:get, "https://api.workos.com/sso/jwks/client_001")
+      .to_return(status: 200, body: jwks_payload(pub).to_json)
+
+    session = @sm.load(seal_data: sealed, cookie_password: PASSWORD)
+    result = session.refresh
+
+    assert_kind_of WorkOS::SessionManager::RefreshSuccess, result
+    assert result.authenticated
+    assert_equal "session_new_v6", result.session_id
+    assert_equal "org_v6", result.organization_id
+    assert_equal "member", result.role
+    assert_equal "u_v6", result.user["id"]
+
+    refute_empty result.sealed_session
+    unsealed = @sm.unseal_data(result.sealed_session, PASSWORD)
+    assert_equal new_access, unsealed["access_token"]
+    assert_equal "rt_new_v6", unsealed["refresh_token"]
+    assert_equal "u_v6", unsealed["user"]["id"]
+  end
+
   def test_refresh_updates_internal_seal_data_for_subsequent_authenticate
     rsa, pub = signing_key_pair
     old_access = make_jwt({"sid" => "session_old", "exp" => Time.now.to_i - 60}, rsa)


### PR DESCRIPTION
## Summary
- Adds a v6 fallback path to `WorkOS::Encryptors::AesGcm#unseal` so cookies sealed by the old `encryptor`-gem format still decrypt after the v7 upgrade.
- Without this, every existing browser cookie would fail to unseal after upgrading and users would be silently logged out — v6 used the raw passphrase as the AES key with no version prefix; v7 prepends a version byte and SHA-256-derives the key.
- Fallback re-raises the original v7 error when both decoders fail, so genuinely malformed payloads still surface accurate errors.
- Adds unit coverage in `test_encryptors_aes_gcm.rb` and an end-to-end `SessionManager#authenticate` test exercising a v6-sealed cookie.

## Test plan
- [ ] `bundle exec rake test TEST=test/workos/test_encryptors_aes_gcm.rb`
- [ ] `bundle exec rake test TEST=test/workos/test_session.rb`
- [ ] Manually verify a session cookie sealed by the previous SDK version still authenticates against this build.