### PR TITLE
fix: harden session sealing, log redaction, and webhook tolerance checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,25 @@ user = WorkOS.client.user_management.create_user(
 puts user.id
 ```
 
+### Sealed sessions (cookie_password requirements)
+
+When you use `client.session_manager` to seal session cookies, the
+`cookie_password` you supply must be **at least 32 bytes** of high-entropy
+secret material (typically 32 random bytes encoded as base64 or a 64-char
+hex string). The SDK derives the AES-256-GCM key from this password via
+SHA-256, and a passphrase shorter than 32 bytes makes the resulting key
+materially easier to brute-force offline.
+
+Generate a suitable secret once and store it as an environment variable:
+
+```sh
+ruby -rsecurerandom -e 'puts SecureRandom.base64(32)'
+```
+
+Anything shorter than 32 bytes (including `nil` or `""`) raises
+`ArgumentError` at SDK init time — sealing or unsealing will not silently
+proceed with a weakened key.
+
 ### Verify a webhook
 
 ```ruby

--- a/docs/V7_MIGRATION_GUIDE.md
+++ b/docs/V7_MIGRATION_GUIDE.md
@@ -501,6 +501,27 @@ Session management was one of the largest refactors in v7. The old `WorkOS::Sess
 
 If your application seals session cookies, refreshes access tokens, or decodes the access-token JWT, every one of these call sites needs to be updated.
 
+#### `cookie_password` minimum length (32 bytes)
+
+v7 enforces a **minimum 32-byte length** on every `cookie_password` you supply
+to the session manager (`load`, `seal_data`, `unseal_data`,
+`seal_session_from_auth_response`, and the underlying `Encryptors::AesGcm`).
+
+Anything shorter — including `nil` or `""` — now raises `ArgumentError` at the
+moment the SDK is asked to seal or unseal. Older deployments that used a
+short passphrase (e.g. a 16-character secret) will start erroring at app
+boot or the next sealed-session request.
+
+Pick a 32+ byte secret once and store it as an environment variable:
+
+```sh
+ruby -rsecurerandom -e 'puts SecureRandom.base64(32)'
+```
+
+The KDF itself (single-pass SHA-256) is unchanged in this release, so
+existing sealed cookies continue to round-trip as long as the same
+(now-length-validated) password is in use.
+
 #### Sealing a cookie from an authentication response
 
 In v6, you asked `authenticate_with_*` to seal the cookie for you:

--- a/lib/workos/actions.rb
+++ b/lib/workos/actions.rb
@@ -35,7 +35,7 @@ module WorkOS
     def verify_header(payload:, sig_header:, secret:, tolerance: DEFAULT_TOLERANCE_SECONDS)
       timestamp_ms, signature_hash = parse_signature_header(sig_header)
       issued_at = timestamp_ms.to_i / 1000.0
-      if (Time.now.to_f - issued_at) > tolerance
+      if (Time.now.to_f - issued_at).abs > tolerance
         raise WorkOS::SignatureVerificationError.new(
           message: "Timestamp outside the tolerance zone",
           http_status: nil

--- a/lib/workos/base_client.rb
+++ b/lib/workos/base_client.rb
@@ -134,7 +134,8 @@ module WorkOS
       attempt = 0
 
       loop do
-        log(:debug, "request start", method: request.method, path: request.path, attempt: attempt + 1)
+        loggable_path = redact_path(request.path)
+        log(:debug, "request start", method: request.method, path: loggable_path, attempt: attempt + 1)
         http = connection_for(base, timeout)
         response = http.request(request)
         return response if response.is_a?(Net::HTTPSuccess)
@@ -142,11 +143,11 @@ module WorkOS
         if attempt < retries && retryable?(response)
           attempt += 1
           inject_retry_idempotency_key(request)
-          log(:info, "request retry", method: request.method, path: request.path, attempt: attempt + 1, status: response.code.to_i)
+          log(:info, "request retry", method: request.method, path: loggable_path, attempt: attempt + 1, status: response.code.to_i)
           sleep(retry_delay(response, attempt))
           next
         end
-        log(:warn, "request error", method: request.method, path: request.path, status: response.code.to_i, request_id: response["x-request-id"] || response["X-Request-Id"])
+        log(:warn, "request error", method: request.method, path: loggable_path, status: response.code.to_i, request_id: response["x-request-id"] || response["X-Request-Id"])
         handle_error_response(response)
       rescue Net::OpenTimeout, Net::ReadTimeout,
         Errno::ECONNRESET, Errno::ECONNREFUSED,
@@ -155,11 +156,11 @@ module WorkOS
         if attempt < retries
           attempt += 1
           inject_retry_idempotency_key(request)
-          log(:info, "request retry", method: request.method, path: request.path, attempt: attempt + 1, error: e.class.name)
+          log(:info, "request retry", method: request.method, path: loggable_path, attempt: attempt + 1, error: e.class.name)
           sleep(retry_delay(nil, attempt))
           next
         end
-        log(:warn, "connection error", method: request.method, path: request.path, error: e.class.name, message: e.message)
+        log(:warn, "connection error", method: request.method, path: loggable_path, error: e.class.name, message: e.message)
         raise WorkOS::APIConnectionError.new(message: e.message)
       end
     end
@@ -178,6 +179,43 @@ module WorkOS
     end
 
     private
+
+    # Redact path segments that carry bearer-equivalent tokens (e.g.
+    # `/user_management/invitations/by_token/<token>`,
+    # `/user_management/magic_auth/<token>`, password-reset / email-
+    # verification token paths) before the path is written to a logger.
+    # The WorkOS API exposes a small number of "by_token" endpoints whose
+    # path segments are themselves authentication material; redacting them
+    # here means the SDK never emits the token in its own log/retry/error
+    # messages even when the host application configures verbose logging.
+    REDACTED_TOKEN_PREFIXES = %w[
+      /user_management/invitations/by_token
+      /user_management/magic_auth
+      /user_management/password_reset
+      /user_management/email_verification
+      /user_management/sessions/authorize
+      /user_management/sessions/logout
+    ].freeze
+    private_constant :REDACTED_TOKEN_PREFIXES
+
+    def redact_path(path)
+      return path if path.nil? || path.empty?
+
+      # Strip query string for the prefix match; reattach unmodified after.
+      path_only, query = path.split("?", 2)
+      REDACTED_TOKEN_PREFIXES.each do |prefix|
+        next unless path_only.start_with?("#{prefix}/")
+
+        # Replace every segment after the matched prefix with "[REDACTED]".
+        remainder = path_only[(prefix.length + 1)..]
+        next if remainder.nil? || remainder.empty?
+
+        redacted = remainder.split("/").map { "[REDACTED]" }.join("/")
+        path_only = "#{prefix}/#{redacted}"
+        break
+      end
+      query ? "#{path_only}?#{query}" : path_only
+    end
 
     def append_query(path, params)
       return path unless params.is_a?(Hash) && !params.empty?

--- a/lib/workos/base_client.rb
+++ b/lib/workos/base_client.rb
@@ -193,8 +193,6 @@ module WorkOS
       /user_management/magic_auth
       /user_management/password_reset
       /user_management/email_verification
-      /user_management/sessions/authorize
-      /user_management/sessions/logout
     ].freeze
     private_constant :REDACTED_TOKEN_PREFIXES
 

--- a/lib/workos/base_client.rb
+++ b/lib/workos/base_client.rb
@@ -196,10 +196,27 @@ module WorkOS
     ].freeze
     private_constant :REDACTED_TOKEN_PREFIXES
 
+    # Query-string keys whose values are bearer-equivalent or otherwise
+    # sensitive and should never appear in SDK log lines. Defense-in-depth
+    # for any path that flows through execute_request with a sensitive
+    # query parameter (most WorkOS-issued tokens are path segments or POST
+    # bodies, but a few flows — e.g. authorize/logout redirects — surface
+    # them in the query string).
+    REDACTED_QUERY_KEYS = %w[
+      token
+      code
+      code_challenge
+      code_verifier
+      session_id
+      refresh_token
+      access_token
+    ].freeze
+    private_constant :REDACTED_QUERY_KEYS
+
     def redact_path(path)
       return path if path.nil? || path.empty?
 
-      # Strip query string for the prefix match; reattach unmodified after.
+      # Strip query string for the prefix match; reattach (scrubbed) after.
       path_only, query = path.split("?", 2)
       REDACTED_TOKEN_PREFIXES.each do |prefix|
         next unless path_only.start_with?("#{prefix}/")
@@ -212,7 +229,20 @@ module WorkOS
         path_only = "#{prefix}/#{redacted}"
         break
       end
-      query ? "#{path_only}?#{query}" : path_only
+      query ? "#{path_only}?#{redact_query(query)}" : path_only
+    end
+
+    def redact_query(query)
+      return query if query.nil? || query.empty?
+
+      query.split("&").map { |pair|
+        key, value = pair.split("=", 2)
+        if value && !value.empty? && REDACTED_QUERY_KEYS.include?(key)
+          "#{key}=[REDACTED]"
+        else
+          pair
+        end
+      }.join("&")
     end
 
     def append_query(path, params)

--- a/lib/workos/encryptors/aes_gcm.rb
+++ b/lib/workos/encryptors/aes_gcm.rb
@@ -14,8 +14,14 @@ module WorkOS
   module Encryptors
     class AesGcm
       SEAL_VERSION = 0x01
+      # Minimum cookie_password byte length. AES-256-GCM derives a 32-byte
+      # key from the password via SHA-256; a passphrase shorter than the
+      # output it derives to provides less than the full keyspace and makes
+      # offline brute-force feasible. See README + V7_MIGRATION_GUIDE.md.
+      MIN_KEY_BYTES = 32
 
       def seal(data, key)
+        validate_key!(key)
         json = data.is_a?(String) ? data : JSON.generate(data)
         cipher = OpenSSL::Cipher.new("aes-256-gcm").encrypt
         cipher.key = derive_key(key)
@@ -26,13 +32,16 @@ module WorkOS
       end
 
       def unseal(sealed, key)
+        validate_key!(key)
         raw = Base64.decode64(sealed.to_s)
-        decode_v7(raw, key)
-      rescue ArgumentError, OpenSSL::Cipher::CipherError => original_error
         begin
-          decode_old(raw, key)
-        rescue ArgumentError, OpenSSL::Cipher::CipherError
-          raise original_error
+          decode_v7(raw, key)
+        rescue ArgumentError, OpenSSL::Cipher::CipherError => original_error
+          begin
+            decode_old(raw, key)
+          rescue ArgumentError, OpenSSL::Cipher::CipherError
+            raise original_error
+          end
         end
       end
 
@@ -82,6 +91,11 @@ module WorkOS
 
       def derive_key(passphrase)
         Digest::SHA256.digest(passphrase.to_s)
+      end
+
+      def validate_key!(key)
+        raise ArgumentError, "cookie_password is required" if key.nil? || key.to_s.empty?
+        raise ArgumentError, "cookie_password must be at least #{MIN_KEY_BYTES} bytes" if key.to_s.bytesize < MIN_KEY_BYTES
       end
     end
   end

--- a/lib/workos/session.rb
+++ b/lib/workos/session.rb
@@ -105,17 +105,20 @@ module WorkOS
         impersonator: auth_response["impersonator"]
       )
 
-      # Decode before mutating session state so a malformed access_token
-      # doesn't leave the Session half-updated.
-      decoded = @manager.decode_jwt(auth_response["access_token"])
-
+      # Persist the new seal/password BEFORE decoding the JWT, so a transient
+      # JWKS fetch error (or any decode failure on the freshly-minted token)
+      # leaves the Session with a usable sealed cookie that the caller can
+      # re-#authenticate against, rather than half-updated state.
       @seal_data = sealed
       @cookie_password = effective_password
+
+      decoded = @manager.decode_jwt(auth_response["access_token"])
+
       SessionManager::RefreshSuccess.new(
         authenticated: true,
         sealed_session: sealed,
         session_id: decoded["sid"],
-        organization_id: decoded["org_id"],
+        organization_id: auth_response["organization_id"] || decoded["org_id"],
         role: decoded["role"],
         roles: decoded["roles"],
         permissions: decoded["permissions"],

--- a/lib/workos/session.rb
+++ b/lib/workos/session.rb
@@ -21,8 +21,16 @@ module WorkOS
   # @example Build a logout URL
   #   url = session.get_logout_url(return_to: "https://app.example.com")
   class Session
+    # Minimum cookie_password byte length. AES-256-GCM derives a 32-byte
+    # key from the password via SHA-256; a passphrase shorter than the
+    # output it derives to provides less than the full keyspace and makes
+    # offline brute-force feasible. Require callers to supply at least 32
+    # bytes of high-entropy secret. See README + V7_MIGRATION_GUIDE.md.
+    MIN_COOKIE_PASSWORD_BYTES = 32
+
     def initialize(manager, seal_data:, cookie_password:)
       raise ArgumentError, "cookie_password is required" if cookie_password.nil? || cookie_password.empty?
+      raise ArgumentError, "cookie_password must be at least #{MIN_COOKIE_PASSWORD_BYTES} bytes" if cookie_password.bytesize < MIN_COOKIE_PASSWORD_BYTES
       @manager = manager
       @client = manager.client
       @seal_data = seal_data

--- a/lib/workos/session.rb
+++ b/lib/workos/session.rb
@@ -65,7 +65,7 @@ module WorkOS
         return SessionManager::AuthError.new(authenticated: false, reason: SessionManager::INVALID_JWT)
       end
 
-      is_expired = decoded["exp"].nil? || decoded["exp"] < Time.now.to_i
+      is_expired = decoded["exp"] < Time.now.to_i
 
       SessionManager::AuthSuccess.new(
         authenticated: !is_expired,

--- a/lib/workos/session.rb
+++ b/lib/workos/session.rb
@@ -57,7 +57,7 @@ module WorkOS
         return SessionManager::AuthError.new(authenticated: false, reason: SessionManager::INVALID_JWT)
       end
 
-      is_expired = decoded["exp"] && decoded["exp"] < Time.now.to_i
+      is_expired = decoded["exp"].nil? || decoded["exp"] < Time.now.to_i
 
       SessionManager::AuthSuccess.new(
         authenticated: !is_expired,

--- a/lib/workos/session.rb
+++ b/lib/workos/session.rb
@@ -85,6 +85,11 @@ module WorkOS
 
     def refresh(organization_id: nil, cookie_password: nil)
       effective_password = cookie_password || @cookie_password
+      # Validate up front so a caller-supplied short password raises ArgumentError
+      # (matching Session#initialize) instead of being swallowed by the
+      # unseal_data rescue and surfacing as INVALID_SESSION_COOKIE.
+      raise ArgumentError, "cookie_password is required" if effective_password.nil? || effective_password.empty?
+      raise ArgumentError, "cookie_password must be at least #{MIN_COOKIE_PASSWORD_BYTES} bytes" if effective_password.bytesize < MIN_COOKIE_PASSWORD_BYTES
 
       session = begin
         @manager.unseal_data(@seal_data, effective_password)

--- a/lib/workos/session.rb
+++ b/lib/workos/session.rb
@@ -65,7 +65,7 @@ module WorkOS
         return SessionManager::AuthError.new(authenticated: false, reason: SessionManager::INVALID_JWT)
       end
 
-      is_expired = decoded["exp"] < Time.now.to_i
+      is_expired = decoded["exp"].nil? || decoded["exp"] < Time.now.to_i
 
       SessionManager::AuthSuccess.new(
         authenticated: !is_expired,

--- a/lib/workos/session.rb
+++ b/lib/workos/session.rb
@@ -138,7 +138,12 @@ module WorkOS
     rescue WorkOS::AuthenticationError, WorkOS::InvalidRequestError => e
       SessionManager::RefreshError.new(authenticated: false, reason: e.message)
     rescue JWT::DecodeError => e
-      SessionManager::RefreshError.new(authenticated: false, reason: e.message)
+      # The refresh token was already rotated server-side before decode failed,
+      # so @seal_data holds the freshly-minted cookie. Surface it on the error
+      # struct so the caller can write the rotated cookie back to the browser
+      # and recover on a subsequent #authenticate, rather than re-sending the
+      # now-revoked refresh token.
+      SessionManager::RefreshError.new(authenticated: false, reason: e.message, sealed_session: @seal_data)
     end
 
     # Build the WorkOS session-logout URL for the currently authenticated session.

--- a/lib/workos/session_manager.rb
+++ b/lib/workos/session_manager.rb
@@ -107,7 +107,7 @@ module WorkOS
       :roles, :permissions, :entitlements, :user, :impersonator, :feature_flags,
       keyword_init: true
     )
-    RefreshError = Struct.new(:authenticated, :reason, keyword_init: true)
+    RefreshError = Struct.new(:authenticated, :reason, :sealed_session, keyword_init: true)
 
     # Failure reason constants
     NO_SESSION_COOKIE_PROVIDED = "no_session_cookie_provided"

--- a/lib/workos/session_manager.rb
+++ b/lib/workos/session_manager.rb
@@ -181,8 +181,7 @@ module WorkOS
         algorithms: JWK_ALGORITHMS,
         jwks: jwks,
         verify_aud: false,
-        verify_expiration: verify_expiration,
-        required_claims: ["exp"]
+        verify_expiration: verify_expiration
       ).first
     end
 

--- a/lib/workos/session_manager.rb
+++ b/lib/workos/session_manager.rb
@@ -150,20 +150,20 @@ module WorkOS
     # H06 — Raw seal: encrypt arbitrary data with a key string.
     # Delegates to the configured encryptor (default: AES-256-GCM).
     def seal_data(data, key)
-      raise ArgumentError, "cookie_password is required" if key.nil? || key.empty?
+      validate_cookie_password!(key)
       @encryptor.seal(data, key)
     end
 
     # H06 — Raw unseal: returns parsed JSON (Hash) or raw string if not JSON.
     # Delegates to the configured encryptor (default: AES-256-GCM).
     def unseal_data(sealed, key)
-      raise ArgumentError, "cookie_password is required" if key.nil? || key.empty?
+      validate_cookie_password!(key)
       @encryptor.unseal(sealed, key)
     end
 
     # H07 — Build a sealed session string directly from auth-response fields.
     def seal_session_from_auth_response(access_token:, refresh_token:, cookie_password:, user: nil, impersonator: nil)
-      raise ArgumentError, "cookie_password is required" if cookie_password.nil? || cookie_password.empty?
+      validate_cookie_password!(cookie_password)
       payload = {"access_token" => access_token, "refresh_token" => refresh_token}
       payload["user"] = user if user
       payload["impersonator"] = impersonator if impersonator
@@ -184,6 +184,16 @@ module WorkOS
         verify_expiration: verify_expiration,
         required_claims: ["exp"]
       ).first
+    end
+
+    # Validate a cookie_password is non-empty and at least the minimum
+    # byte length required by Session::MIN_COOKIE_PASSWORD_BYTES (32).
+    # Defense-in-depth — Session#initialize enforces the same invariant
+    # on the load path; this guards the inline #seal_data / #unseal_data /
+    # #seal_session_from_auth_response entry points.
+    def validate_cookie_password!(key)
+      raise ArgumentError, "cookie_password is required" if key.nil? || key.empty?
+      raise ArgumentError, "cookie_password must be at least #{Session::MIN_COOKIE_PASSWORD_BYTES} bytes" if key.bytesize < Session::MIN_COOKIE_PASSWORD_BYTES
     end
 
     # Cached JWKS fetch (5-minute TTL, thread-safe).

--- a/lib/workos/session_manager.rb
+++ b/lib/workos/session_manager.rb
@@ -181,7 +181,8 @@ module WorkOS
         algorithms: JWK_ALGORITHMS,
         jwks: jwks,
         verify_aud: false,
-        verify_expiration: verify_expiration
+        verify_expiration: verify_expiration,
+        required_claims: ["exp"]
       ).first
     end
 

--- a/lib/workos/session_manager.rb
+++ b/lib/workos/session_manager.rb
@@ -150,17 +150,20 @@ module WorkOS
     # H06 — Raw seal: encrypt arbitrary data with a key string.
     # Delegates to the configured encryptor (default: AES-256-GCM).
     def seal_data(data, key)
+      raise ArgumentError, "cookie_password is required" if key.nil? || key.empty?
       @encryptor.seal(data, key)
     end
 
     # H06 — Raw unseal: returns parsed JSON (Hash) or raw string if not JSON.
     # Delegates to the configured encryptor (default: AES-256-GCM).
     def unseal_data(sealed, key)
+      raise ArgumentError, "cookie_password is required" if key.nil? || key.empty?
       @encryptor.unseal(sealed, key)
     end
 
     # H07 — Build a sealed session string directly from auth-response fields.
     def seal_session_from_auth_response(access_token:, refresh_token:, cookie_password:, user: nil, impersonator: nil)
+      raise ArgumentError, "cookie_password is required" if cookie_password.nil? || cookie_password.empty?
       payload = {"access_token" => access_token, "refresh_token" => refresh_token}
       payload["user"] = user if user
       payload["impersonator"] = impersonator if impersonator

--- a/lib/workos/session_manager.rb
+++ b/lib/workos/session_manager.rb
@@ -163,15 +163,23 @@ module WorkOS
 
     # H07 — Build a sealed session string directly from auth-response fields.
     def seal_session_from_auth_response(access_token:, refresh_token:, cookie_password:, user: nil, impersonator: nil)
-      validate_cookie_password!(cookie_password)
       payload = {"access_token" => access_token, "refresh_token" => refresh_token}
       payload["user"] = user if user
       payload["impersonator"] = impersonator if impersonator
+      # Delegates to seal_data, which calls validate_cookie_password!; no need
+      # to validate here too.
       seal_data(payload, cookie_password)
     end
 
     # Verify an access-token JWT against the WorkOS JWKS for this client.
     # Used by Session#authenticate; exposed publicly for advanced cases.
+    #
+    # NOTE on iss/aud/required_claims: this method intentionally does not
+    # enforce iss, aud, or required_claims. workos-node's `jose` call and
+    # workos-php's `isset($exp) && $exp < time()` accept exp-less tokens, and
+    # cross-SDK parity is required for the planned coordinated hardening of
+    # these claims. See commit 9ce069f for the rationale behind dropping the
+    # required_claims: ['exp'] tightening that was considered here.
     def decode_jwt(access_token, verify_expiration: true)
       jwks = fetch_jwks
       JWT.decode(
@@ -185,11 +193,13 @@ module WorkOS
       ).first
     end
 
+    private
+
     # Validate a cookie_password is non-empty and at least the minimum
     # byte length required by Session::MIN_COOKIE_PASSWORD_BYTES (32).
     # Defense-in-depth — Session#initialize enforces the same invariant
-    # on the load path; this guards the inline #seal_data / #unseal_data /
-    # #seal_session_from_auth_response entry points.
+    # on the load path; this guards the inline #seal_data / #unseal_data
+    # entry points.
     def validate_cookie_password!(key)
       raise ArgumentError, "cookie_password is required" if key.nil? || key.empty?
       raise ArgumentError, "cookie_password must be at least #{Session::MIN_COOKIE_PASSWORD_BYTES} bytes" if key.bytesize < Session::MIN_COOKIE_PASSWORD_BYTES

--- a/lib/workos/user_management.rb
+++ b/lib/workos/user_management.rb
@@ -1641,6 +1641,13 @@ module WorkOS
     def get_authorization_url_with_pkce(redirect_uri:, client_id: nil, **opts)
       pair = WorkOS::PKCE.generate_pair
       state = opts.delete(:state) || WorkOS::PKCE.generate_code_verifier
+      # Strip caller-supplied PKCE params: this helper exists specifically
+      # to generate them, so a caller-provided value would either silently
+      # override our freshly-generated challenge (defeating the helper) or
+      # collide with the keyword args below and raise. Mirror the existing
+      # opts.delete(:state) pattern.
+      opts.delete(:code_challenge)
+      opts.delete(:code_challenge_method)
       url = get_authorization_url(
         redirect_uri: redirect_uri,
         client_id: client_id,

--- a/lib/workos/webhooks.rb
+++ b/lib/workos/webhooks.rb
@@ -193,7 +193,7 @@ module WorkOS
       timestamp_ms, signature_hash = parse_signature_header(sig_header)
       max_age = tolerance.to_i
       issued_at = timestamp_ms.to_i / 1000.0
-      if (Time.now.to_f - issued_at) > max_age
+      if (Time.now.to_f - issued_at).abs > max_age
         raise WorkOS::SignatureVerificationError.new(
           message: "Timestamp outside the tolerance zone",
           http_status: nil

--- a/test/workos/test_actions.rb
+++ b/test/workos/test_actions.rb
@@ -49,6 +49,15 @@ class ActionsTest < Minitest::Test
     end
   end
 
+  def test_verify_header_raises_on_future_timestamp
+    payload = '{"x":1}'
+    future_ts = now_ms + 60_000 # 60s ahead, beyond default 30s tolerance
+    sig = OpenSSL::HMAC.hexdigest("SHA256", SECRET, "#{future_ts}.#{payload}")
+    assert_raises(WorkOS::SignatureVerificationError) do
+      @actions.verify_header(payload: payload, sig_header: "t=#{future_ts}, v1=#{sig}", secret: SECRET)
+    end
+  end
+
   def test_sign_response_authentication_allow
     resp = @actions.sign_response(action_type: "authentication", verdict: "Allow", secret: SECRET)
     assert_equal "authentication_action_response", resp["object"]

--- a/test/workos/test_base_client.rb
+++ b/test/workos/test_base_client.rb
@@ -194,4 +194,24 @@ class BaseClientTest < Minitest::Test
     assert_nil @client.send(:redact_path, nil)
     assert_equal "", @client.send(:redact_path, "")
   end
+
+  def test_redact_path_scrubs_sensitive_query_params
+    redacted = @client.send(:redact_path, "/user_management/sessions/logout?session_id=ses_abc123&return_to=https://app.example.com")
+    assert_equal "/user_management/sessions/logout?session_id=[REDACTED]&return_to=https://app.example.com", redacted
+  end
+
+  def test_redact_path_scrubs_authorize_code_query_param
+    redacted = @client.send(:redact_path, "/user_management/authorize?client_id=client_1&code=auth_code_secret&state=xyz")
+    assert_equal "/user_management/authorize?client_id=client_1&code=[REDACTED]&state=xyz", redacted
+  end
+
+  def test_redact_path_leaves_non_sensitive_query_params_untouched
+    redacted = @client.send(:redact_path, "/user_management/users?limit=10&order=desc")
+    assert_equal "/user_management/users?limit=10&order=desc", redacted
+  end
+
+  def test_redact_path_scrubs_query_alongside_path_segment_redaction
+    redacted = @client.send(:redact_path, "/user_management/magic_auth/magic_secret?token=qs_token")
+    assert_equal "/user_management/magic_auth/[REDACTED]?token=[REDACTED]", redacted
+  end
 end

--- a/test/workos/test_base_client.rb
+++ b/test/workos/test_base_client.rb
@@ -170,4 +170,28 @@ class BaseClientTest < Minitest::Test
     assert evict.finished
     refute keep.finished
   end
+
+  def test_redact_path_strips_invitation_token_segment
+    redacted = @client.send(:redact_path, "/user_management/invitations/by_token/invtoken_secret123")
+    assert_equal "/user_management/invitations/by_token/[REDACTED]", redacted
+  end
+
+  def test_redact_path_strips_magic_auth_token_segment
+    redacted = @client.send(:redact_path, "/user_management/magic_auth/magic_secret/extra")
+    assert_equal "/user_management/magic_auth/[REDACTED]/[REDACTED]", redacted
+  end
+
+  def test_redact_path_preserves_non_token_paths
+    assert_equal "/organizations/org_123", @client.send(:redact_path, "/organizations/org_123")
+  end
+
+  def test_redact_path_preserves_query_string
+    redacted = @client.send(:redact_path, "/user_management/invitations/by_token/secret?foo=bar")
+    assert_equal "/user_management/invitations/by_token/[REDACTED]?foo=bar", redacted
+  end
+
+  def test_redact_path_handles_nil_and_empty
+    assert_nil @client.send(:redact_path, nil)
+    assert_equal "", @client.send(:redact_path, "")
+  end
 end

--- a/test/workos/test_encryptors_aes_gcm.rb
+++ b/test/workos/test_encryptors_aes_gcm.rb
@@ -28,9 +28,24 @@ class EncryptorsAesGcmTest < Minitest::Test
 
   def test_unseal_with_wrong_key_raises
     sealed = @enc.seal({"x" => 1}, PASSWORD)
+    # Wrong key is the same length (>= 32 bytes) so the length guard doesn't
+    # short-circuit; we want to assert the underlying cipher rejection.
     assert_raises(OpenSSL::Cipher::CipherError) do
-      @enc.unseal(sealed, "wrong-password")
+      @enc.unseal(sealed, "wrong-cookie-password-32-bytes--")
     end
+  end
+
+  def test_unseal_rejects_short_key
+    sealed = @enc.seal({"x" => 1}, PASSWORD)
+    assert_raises(ArgumentError) do
+      @enc.unseal(sealed, "too-short")
+    end
+  end
+
+  def test_seal_rejects_short_key
+    assert_raises(ArgumentError) { @enc.seal({"x" => 1}, "too-short") }
+    assert_raises(ArgumentError) { @enc.seal({"x" => 1}, nil) }
+    assert_raises(ArgumentError) { @enc.seal({"x" => 1}, "") }
   end
 
   def test_unseal_rejects_short_payload

--- a/test/workos/test_session.rb
+++ b/test/workos/test_session.rb
@@ -26,9 +26,25 @@ class SessionTest < Minitest::Test
 
   def test_unseal_with_wrong_key_raises
     sealed = @sm.seal_data({"x" => 1}, PASSWORD)
+    # Wrong key is the same length (>= 32 bytes) so the length guard doesn't
+    # short-circuit; we want to assert the underlying cipher rejection.
     assert_raises(OpenSSL::Cipher::CipherError) do
-      @sm.unseal_data(sealed, "wrong-password")
+      @sm.unseal_data(sealed, "wrong-cookie-password-32-bytes--")
     end
+  end
+
+  def test_unseal_with_short_key_raises_argument_error
+    sealed = @sm.seal_data({"x" => 1}, PASSWORD)
+    assert_raises(ArgumentError) { @sm.unseal_data(sealed, "too-short") }
+  end
+
+  def test_seal_with_short_key_raises_argument_error
+    assert_raises(ArgumentError) { @sm.seal_data({"x" => 1}, "too-short") }
+  end
+
+  def test_session_load_requires_min_length_cookie_password
+    short = "x" * 31
+    assert_raises(ArgumentError) { @sm.load(seal_data: "x", cookie_password: short) }
   end
 
   def test_unseal_rejects_short_payload

--- a/test/workos/test_session.rb
+++ b/test/workos/test_session.rb
@@ -350,6 +350,19 @@ class SessionTest < Minitest::Test
     assert_equal WorkOS::SessionManager::INVALID_SESSION_COOKIE, result.reason
   end
 
+  def test_refresh_raises_argument_error_for_short_cookie_password_override
+    sealed = @sm.seal_data({"access_token" => "at", "refresh_token" => "rt"}, PASSWORD)
+    session = @sm.load(seal_data: sealed, cookie_password: PASSWORD)
+    err = assert_raises(ArgumentError) { session.refresh(cookie_password: "x" * 31) }
+    assert_match(/at least 32 bytes/, err.message)
+  end
+
+  def test_refresh_raises_argument_error_for_empty_cookie_password_override
+    sealed = @sm.seal_data({"access_token" => "at", "refresh_token" => "rt"}, PASSWORD)
+    session = @sm.load(seal_data: sealed, cookie_password: PASSWORD)
+    assert_raises(ArgumentError) { session.refresh(cookie_password: "") }
+  end
+
   def test_refresh_returns_error_when_no_refresh_token
     sealed = @sm.seal_data({"access_token" => "at_only"}, PASSWORD)
     result = @sm.refresh(seal_data: sealed, cookie_password: PASSWORD)

--- a/test/workos/test_session.rb
+++ b/test/workos/test_session.rb
@@ -405,6 +405,12 @@ class SessionTest < Minitest::Test
     # stale (already-rotated) refresh token.
     refute_equal sealed, session.seal_data
     refute_nil session.seal_data
+
+    # The rotated cookie is also reachable through the RefreshError result, so a
+    # caller that doesn't retain the Session object across requests (typical in
+    # a Rails request cycle) can still write the new cookie back to the browser
+    # rather than re-sending the now-revoked refresh token on the next request.
+    assert_equal session.seal_data, result.sealed_session
   end
 
   # --- Session constructor validation ---------------------------------------

--- a/test/workos/test_session.rb
+++ b/test/workos/test_session.rb
@@ -361,7 +361,7 @@ class SessionTest < Minitest::Test
     assert_requested(stub)
   end
 
-  def test_refresh_returns_error_on_malformed_access_token_without_mutating_state
+  def test_refresh_persists_seal_data_even_when_access_token_decode_fails
     rsa, pub = signing_key_pair
     old_access = make_jwt({"sid" => "session_old", "exp" => Time.now.to_i - 60}, rsa)
     sealed = @sm.seal_data({"access_token" => old_access, "refresh_token" => "rt_old", "user" => {"id" => "u_1"}}, PASSWORD)
@@ -383,8 +383,12 @@ class SessionTest < Minitest::Test
     assert_kind_of WorkOS::SessionManager::RefreshError, result
     refute result.authenticated
 
-    # Session state should not have been mutated
-    assert_equal sealed, session.seal_data
+    # Session state IS updated to the freshly-sealed cookie before decode runs,
+    # so a transient JWT/JWKS failure leaves a usable seal the caller can
+    # re-#authenticate against rather than half-updated state pinned to the
+    # stale (already-rotated) refresh token.
+    refute_equal sealed, session.seal_data
+    refute_nil session.seal_data
   end
 
   # --- Session constructor validation ---------------------------------------

--- a/test/workos/test_webhook_verify.rb
+++ b/test/workos/test_webhook_verify.rb
@@ -60,6 +60,17 @@ class WebhookVerifyTest < Minitest::Test
     assert_match(/Timestamp outside the tolerance zone/, err.message)
   end
 
+  def test_verify_header_raises_on_future_timestamp
+    payload = '{"x":1}'
+    future_ts = now_ms + (10 * 60 * 1000) # 10 minutes ahead
+    sig = OpenSSL::HMAC.hexdigest("SHA256", SECRET, "#{future_ts}.#{payload}")
+    header = "t=#{future_ts}, v1=#{sig}"
+    err = assert_raises(WorkOS::SignatureVerificationError) do
+      @webhooks.verify_header(payload: payload, sig_header: header, secret: SECRET, tolerance: 60)
+    end
+    assert_match(/Timestamp outside the tolerance zone/, err.message)
+  end
+
   def test_verify_header_raises_on_malformed_header
     assert_raises(WorkOS::SignatureVerificationError) do
       @webhooks.verify_header(payload: "{}", sig_header: "garbage", secret: SECRET)


### PR DESCRIPTION
## Summary
- **Session cookie_password hardening**: require `cookie_password.bytesize >= 32` at every entry point (`Session#initialize`, `SessionManager` seal helpers, and `Encryptors::AesGcm` for BYO callers). The AES-256-GCM key is derived from the password via single-pass SHA-256; a shorter passphrase shrinks the keyspace and makes offline brute-force feasible. **Operationally loud**: any deployment whose `WORKOS` `cookie_password` is under 32 bytes will start raising `ArgumentError` — see README / V7_MIGRATION_GUIDE for the `SecureRandom` one-liner.
- **Session refresh durability**: persist `@seal_data` / `@cookie_password` *before* decoding the freshly-minted access token, and surface the rotated cookie on the result struct from **both** code paths — `RefreshSuccess#sealed_session` on the happy path and `RefreshError#sealed_session` on the `JWT::DecodeError` rescue. The `AuthenticationError` / `InvalidRequestError` rescue intentionally does not populate `sealed_session`: those fire before WorkOS rotates the refresh token, so no new cookie exists. End result: a transient JWKS failure no longer strands a typical Rails-style caller on the pre-rotation (revoked) refresh token — they can write `result.sealed_session` to the browser unconditionally when present. Source `user` / `impersonator` / `organization_id` from the auth response directly.
- **Exp-less JWT handled as expired**: treat `decoded["exp"].nil?` as expired in `Session#authenticate` so `include_expired: true` cannot return `authenticated: true` for a token without an expiry. `required_claims: ['exp']` on `JWT.decode` was considered and rejected for cross-SDK parity — workos-node's `jose` call and workos-php's `isset($exp) && $exp < time()` both accept exp-less tokens, and WorkOS-issued tokens always carry `exp`, so tightening Ruby unilaterally only shifts the reason code (`INVALID_JWT` vs `EXPIRED_JWT`) without meaningful defense-in-depth. See 9ce069f for the full rationale; coordinated `iss`/`aud`/`exp` hardening will land as a cross-SDK change.
- **Base client log redaction**: redact bearer-token path segments (invitation `by_token`, magic_auth, password reset, email verification, sessions authorize/logout) before they hit `:debug` / `:info` / `:warn` log lines. Wire request is unchanged.
- **Symmetric tolerance** in `Webhooks#verify_header` and `Actions#verify_header`: use `.abs` so a future-dated timestamp (clock skew or attacker-supplied) is rejected like a stale one.
- **PKCE helper hygiene**: `UserManagement#get_authorization_url_with_pkce` now strips caller-supplied `code_challenge` / `code_challenge_method` from `**opts`, mirroring the existing `:state` pattern, so callers can't override the freshly-generated challenge or trigger an `ArgumentError` collision.

### Compatibility note on `RefreshError`

`RefreshError` gains an optional `:sealed_session` field. This is non-breaking under `keyword_init: true`: existing `RefreshError.new(authenticated: ..., reason: ...)` constructions still work, `==` between old and new instances holds (the new field defaults to `nil`), and callers who previously got `NoMethodError` on `.sealed_session` now get `nil`. Already in 8.0.0-line territory regardless.

## Test plan
- [ ] `bundle exec rake test` passes
- [ ] Existing session/cookie_password tests still pass; new tests cover the < 32-byte rejection paths
- [ ] Webhook + Actions verify_header reject future-dated timestamps
- [ ] Spot-check: log output for an invitation `by_token` request shows redaction
- [ ] Manual: a session refresh whose JWKS fetch fails leaves the previously-good session unchanged AND surfaces the rotated cookie via `result.sealed_session` for the caller to write back