### PR TITLE
Add :foobar accessor to AddRolePermission

### DIFF
--- a/lib/workos/authorization/add_role_permission.rb
+++ b/lib/workos/authorization/add_role_permission.rb
@@ -8,7 +8,7 @@ module WorkOS
       slug: :slug
     }.freeze
 
-    attr_accessor :slug
+    attr_accessor :slug, :foobar
 
     def initialize(json)
       hash = self.class.normalize(json)


### PR DESCRIPTION
## Summary
- Adds a `:foobar` attribute to the `attr_accessor` declaration in `WorkOS::AddRolePermission` (lib/workos/authorization/add_role_permission.rb).
- ⚠️ Note: this file is marked auto-generated by oagen ("Do not edit"), and commit 7af2b1c was added to prevent oagen files from being PR'ed.

## Test plan
- [ ] `bundle exec rubocop lib/workos/authorization/add_role_permission.rb`
- [ ] `bundle exec rspec` (or the relevant spec) passes
- [ ] Confirm this manual edit to a generated file is intended